### PR TITLE
Add Apt proxy configuration for FTP URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.1.2 / _Not released yet_
 
+- Add Apt proxy configuration for FTP URIs ([GH-5])
 
 # 0.1.1 / 2013-06-27
 
@@ -14,3 +15,4 @@
 
 
 [GH-2]:  https://github.com/tmatilai/vagrant-proxyconf/issues/2  "Issue 2"
+[GH-5]:  https://github.com/tmatilai/vagrant-proxyconf/issues/5  "Issue 5"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ end
 
 #### Configuration keys
 
-* `config.apt_proxy.http` - The proxy for HTTP URIs
+* `config.apt_proxy.http`  - The proxy for HTTP URIs
 * `config.apt_proxy.https` - The proxy for HTTPS URIs
+* `config.apt_proxy.ftp`   - The proxy for FTP URIs
 
 #### Possible values
 
@@ -62,6 +63,7 @@ end
 
 * `APT_PROXY_HTTP`
 * `APT_PROXY_HTTPS`
+* `APT_PROXY_FTP`
 
 These also override the Vagrantfile configuration. To disable or remove the proxy use "DIRECT" or an empty value.
 

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -10,9 +10,13 @@ module VagrantPlugins
         # HTTPS proxy for Apt
         attr_accessor :https
 
+        # FTP proxy for Apt
+        attr_accessor :ftp
+
         def initialize
           @http  = UNSET_VALUE
           @https = UNSET_VALUE
+          @ftp   = UNSET_VALUE
         end
 
         def finalize!
@@ -21,15 +25,18 @@ module VagrantPlugins
 
           @https = override_from_env_var('https', @https)
           @https = nil if @https == UNSET_VALUE
+
+          @ftp = override_from_env_var('ftp', @ftp)
+          @ftp = nil if @ftp == UNSET_VALUE
         end
 
         def enabled?
-          !http.nil? || !https.nil?
+          !http.nil? || !https.nil? || !ftp.nil?
         end
 
         # @return [String] the full configuration stanza
         def to_s
-          "#{config_for('http')}#{config_for('https')}"
+          %w[http https ftp].map { |proto| config_for(proto) }.join
         end
 
         private
@@ -46,7 +53,7 @@ module VagrantPlugins
 
           attr_reader :proto, :value
 
-          # @param proto [String] the protocol ("http", "https")
+          # @param proto [String] the protocol ("http", "https", ...)
           # @param value [Object] the configuration value
           def initialize(proto, value)
             @proto = proto

--- a/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
@@ -7,7 +7,7 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
 
   before :each do
     # Ensure tests are not affected by environment variables
-    %w[APT_PROXY_HTTP APT_PROXY_HTTPS].each { |k| ENV.delete(k) }
+    %w[APT_PROXY_HTTP APT_PROXY_HTTPS APT_PROXY_FTP].each { |k| ENV.delete(k) }
   end
 
   context "defaults" do
@@ -18,6 +18,7 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
 
   include_examples "apt proxy config", "http"
   include_examples "apt proxy config", "https"
+  include_examples "apt proxy config", "ftp"
 
   context "with both http and https proxies" do
     subject        { config_with(http: "10.2.3.4", https: "ssl-proxy:8443") }
@@ -29,6 +30,7 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
   context "with env var" do
     include_examples "apt proxy env var", "APT_PROXY_HTTP", "http"
     include_examples "apt proxy env var", "APT_PROXY_HTTPS", "https"
+    include_examples "apt proxy env var", "APT_PROXY_FTP", "ftp"
   end
 
 end


### PR DESCRIPTION
Add configuration key `config.apt_proxy.ftp` and environment variable `APT_PROXY_FTP` for specifying the proxy for FTP URIs.

Not sure if someone still uses ftp URIs, but it's easy to add just in case.
