### PR TITLE
Do not add the default port to complete URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.2.1 / _Not released yet_
 
+- Do not add the default port to complete URIs (e.g. `http://proxy`) ([GH-9][])
 
 # 0.2.0 / 2013-07-05
 
@@ -23,3 +24,4 @@
 [GH-5]:  https://github.com/tmatilai/vagrant-proxyconf/issues/5  "Issue 5"
 [GH-7]:  https://github.com/tmatilai/vagrant-proxyconf/issues/7  "Issue 7"
 [GH-8]:  https://github.com/tmatilai/vagrant-proxyconf/issues/8  "Issue 8"
+[GH-9]:  https://github.com/tmatilai/vagrant-proxyconf/issues/9  "Issue 9"

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -84,7 +84,7 @@ module VagrantPlugins
           end
 
           def suffix
-            ":#{default_port}" if value !~ %r{:\d+$}
+            ":#{default_port}" if value !~ %r{:\d+$} && value !~ %r{/}
           end
 
           def default_port

--- a/spec/unit/support/shared/apt_proxy_config.rb
+++ b/spec/unit/support/shared/apt_proxy_config.rb
@@ -9,7 +9,8 @@ def conf_line(proto, name, port = 3142)
   if name == :direct
     %Q{Acquire::#{proto}::Proxy "DIRECT";\n}
   else
-    %Q{Acquire::#{proto}::Proxy "#{proto}://#{name}:#{port}";\n}
+    port = ":#{port}" if port
+    %Q{Acquire::#{proto}::Proxy "#{proto}://#{name}#{port}";\n}
   end
 end
 
@@ -41,7 +42,13 @@ shared_examples "apt proxy config" do |proto|
     context "with protocol and name" do
       subject        { config_with(proto => "#{proto}://proxy.foo.tld") }
       its(:enabled?) { should be_true }
-      its(:to_s)     { should eq conf_line(proto, "proxy.foo.tld") }
+      its(:to_s)     { should eq conf_line(proto, "proxy.foo.tld", nil) }
+    end
+
+    context "with trailing slash" do
+      subject        { config_with(proto => "#{proto}://proxy.foo.tld/") }
+      its(:enabled?) { should be_true }
+      its(:to_s)     { should eq conf_line(proto, "proxy.foo.tld/", nil) }
     end
 
     context "with protocol and name and port" do


### PR DESCRIPTION
If a value includes the scheme, for example `http://proxy/`, we should not add the default port. Thus the default port for that protocol will be used.
