### PR TITLE
Support AWS provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.2.1 / _Not released yet_
 
+- Support AWS provider ([GH-10][])
 - Do not add the default port to complete URIs (e.g. `http://proxy`) ([GH-9][])
 
 # 0.2.0 / 2013-07-05
@@ -25,3 +26,4 @@
 [GH-7]:  https://github.com/tmatilai/vagrant-proxyconf/issues/7  "Issue 7"
 [GH-8]:  https://github.com/tmatilai/vagrant-proxyconf/issues/8  "Issue 8"
 [GH-9]:  https://github.com/tmatilai/vagrant-proxyconf/issues/9  "Issue 9"
+[GH-10]: https://github.com/tmatilai/vagrant-proxyconf/issues/10 "Issue 10"

--- a/lib/vagrant-proxyconf/plugin.rb
+++ b/lib/vagrant-proxyconf/plugin.rb
@@ -35,6 +35,11 @@ module VagrantPlugins
       proxyconf_action_hook = lambda do |hook|
         require_relative 'action/configure_apt_proxy'
         hook.after Vagrant::Action::Builtin::Provision, Action::ConfigureAptProxy
+
+        # vagrant-aws uses a non-standard provision action
+        if VagrantPlugins.const_defined?('AWS')
+          hook.after VagrantPlugins::AWS::Action::TimedProvision, Action::ConfigureAptProxy
+        end
       end
       action_hook 'proxyconf-machine-up', :machine_action_up, &proxyconf_action_hook
       action_hook 'proxyconf-machine-reload', :machine_action_reload, &proxyconf_action_hook


### PR DESCRIPTION
The [vagrant-awsplugin](https://github.com/mitchellh/vagrant-aws) uses a non-standard provision action.
So if the plugin is loaded, we hook to it, too.
