### PR TITLE
Support `rebuild` command of the Digital Ocean provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.2.1 / _Not released yet_
 
 - Support AWS provider ([GH-10][])
+- Support `vagrant rebuild` command of the Digital Ocean provider ([GH-11][])
 - Do not add the default port to complete URIs (e.g. `http://proxy`) ([GH-9][])
 
 # 0.2.0 / 2013-07-05
@@ -27,3 +28,4 @@
 [GH-8]:  https://github.com/tmatilai/vagrant-proxyconf/issues/8  "Issue 8"
 [GH-9]:  https://github.com/tmatilai/vagrant-proxyconf/issues/9  "Issue 9"
 [GH-10]: https://github.com/tmatilai/vagrant-proxyconf/issues/10 "Issue 10"
+[GH-11]: https://github.com/tmatilai/vagrant-proxyconf/issues/11 "Issue 11"

--- a/lib/vagrant-proxyconf/plugin.rb
+++ b/lib/vagrant-proxyconf/plugin.rb
@@ -43,6 +43,7 @@ module VagrantPlugins
       end
       action_hook 'proxyconf-machine-up', :machine_action_up, &proxyconf_action_hook
       action_hook 'proxyconf-machine-reload', :machine_action_reload, &proxyconf_action_hook
+      action_hook 'proxyconf-machine-rebuild', :machine_action_rebuild, &proxyconf_action_hook
     end
   end
 end


### PR DESCRIPTION
The [vagrant-digitalocean](https://github.com/smdahlen/vagrant-digitalocean) plugin provides `vagrant rebuild` command that destroys the VM and creates it again (with the same IP).
Hook to that action, too.
