### PR TITLE
Configure the VM also on `vagrant provision`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.3.1 / _Unreleased_
 
+- Configure the VM also on `vagrant provision` ([GH-12][])
+    * Hook to all commands that trigger provisioning action
 
 # 0.3.0 / 2013-07-12
 
@@ -32,3 +34,4 @@
 [GH-9]:  https://github.com/tmatilai/vagrant-proxyconf/issues/9  "Issue 9"
 [GH-10]: https://github.com/tmatilai/vagrant-proxyconf/issues/10 "Issue 10"
 [GH-11]: https://github.com/tmatilai/vagrant-proxyconf/issues/11 "Issue 11"
+[GH-12]: https://github.com/tmatilai/vagrant-proxyconf/issues/12 "Issue 12"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ vagrant plugin install vagrant-proxyconf
 
 ## Usage
 
-The plugin hooks itself to `vagrant up`, `vagrant reload` and `vagrant rebuild` commands.
+The plugin hooks itself to all Vagrant commands triggering provisioning (e.g. `vagrant up`, `vagrant provision`, etc.). The proxy configurations are written just before provisioners are run.
 
 Proxy settings can be configured in Vagrantfile. In the common case that you want to use the same configuration in all Vagrant machines, you can use _$HOME/.vagrant.d/Vagrantfile_ or environment variables. Package manager specific settings are only used on supporting platforms (i.e. Apt configuration on Debian based systems), so there is no harm using global configuration.
 

--- a/lib/vagrant-proxyconf/plugin.rb
+++ b/lib/vagrant-proxyconf/plugin.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
         Cap::Debian::AptProxyConf
       end
 
-      proxyconf_action_hook = lambda do |hook|
+      action_hook 'proxyconf_configure' do |hook|
         require_relative 'action/configure_apt_proxy'
         hook.after Vagrant::Action::Builtin::Provision, Action::ConfigureAptProxy
 
@@ -44,10 +44,6 @@ module VagrantPlugins
           hook.after VagrantPlugins::AWS::Action::TimedProvision, Action::ConfigureAptProxy
         end
       end
-      action_hook 'proxyconf-machine-up', :machine_action_up, &proxyconf_action_hook
-      action_hook 'proxyconf-machine-reload', :machine_action_reload, &proxyconf_action_hook
-      # Hook to vagrant-digitalocean's `rebuild` command
-      action_hook 'proxyconf-machine-rebuild', :machine_action_rebuild, &proxyconf_action_hook
     end
   end
 end


### PR DESCRIPTION
As configuring the OS definitely fits to the concept of provision, we hook to all commands (machine actions) that include a known Provision action. This also simplifies the code and reduces special cases like `vagrant rebuild` of the Digital Ocean provider (see #11).

Thanks to Patrick Connolly (@patcon) for the push!
