### PR TITLE
Rename Apt environment variables to `VAGRANT_APT_HTTP_PROXY` form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.3.1 / _Unreleased_
 
+- BREAKING: Environment variables for Apt config renamed to `VAGRANT_APT_HTTP_PROXY` etc. ([GH-15][])
 - Configure the VM also on `vagrant provision` ([GH-12][])
     * Hook to all commands that trigger provisioning action
 
@@ -35,3 +36,4 @@
 [GH-10]: https://github.com/tmatilai/vagrant-proxyconf/issues/10 "Issue 10"
 [GH-11]: https://github.com/tmatilai/vagrant-proxyconf/issues/11 "Issue 11"
 [GH-12]: https://github.com/tmatilai/vagrant-proxyconf/issues/12 "Issue 12"
+[GH-15]: https://github.com/tmatilai/vagrant-proxyconf/issues/15 "Issue 15"

--- a/README.md
+++ b/README.md
@@ -77,16 +77,16 @@ end
 
 #### Environment variables
 
-* `APT_PROXY_HTTP`
-* `APT_PROXY_HTTPS`
-* `APT_PROXY_FTP`
+* `VAGRANT_APT_HTTP_PROXY`
+* `VAGRANT_APT_HTTPS_PROXY`
+* `VAGRANT_APT_FTP_PROXY`
 
 These also override the Vagrantfile configuration. To disable or remove the proxy use "DIRECT" or an empty value.
 
 For example to spin up a VM, run:
 
 ```sh
-APT_PROXY_HTTP="proxy.example.com:8080" vagrant up
+VAGRANT_APT_HTTP_PROXY="proxy.example.com:8080" vagrant up
 ```
 
 #### Running apt-cacher-ng on a Vagrant box

--- a/development/README.md
+++ b/development/README.md
@@ -11,7 +11,7 @@
 3. Test, hack, edit _Vagrantfile_ and test again:
 
         VAGRANT_LOG=debug bundle exec vagrant reload
-        APT_PROXY_HTTP="foo:8080" bundle exec vagrant reload
+        VAGRANT_APT_HTTP_PROXY="foo:8080" bundle exec vagrant provision
         # ...
 
 4. Goto 3.

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
         private
 
         def override_from_env_var(proto, default)
-          ENV.fetch("APT_PROXY_#{proto.upcase}", default)
+          ENV.fetch("VAGRANT_APT_#{proto.upcase}_PROXY", default)
         end
 
         def config_for(proto)

--- a/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
@@ -7,7 +7,7 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
 
   before :each do
     # Ensure tests are not affected by environment variables
-    %w[APT_PROXY_HTTP APT_PROXY_HTTPS APT_PROXY_FTP].each { |k| ENV.delete(k) }
+    %w[HTTP HTTPS FTP].map { |proto| ENV.delete("VAGRANT_APT_#{proto}_PROXY") }
   end
 
   context "defaults" do
@@ -28,9 +28,9 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
   end
 
   context "with env var" do
-    include_examples "apt proxy env var", "APT_PROXY_HTTP", "http"
-    include_examples "apt proxy env var", "APT_PROXY_HTTPS", "https"
-    include_examples "apt proxy env var", "APT_PROXY_FTP", "ftp"
+    include_examples "apt proxy env var", "VAGRANT_APT_HTTP_PROXY", "http"
+    include_examples "apt proxy env var", "VAGRANT_APT_HTTPS_PROXY", "https"
+    include_examples "apt proxy env var", "VAGRANT_APT_FTP_PROXY", "ftp"
   end
 
 end


### PR DESCRIPTION
Be consistent with all future environment variables: https://gist.github.com/tmatilai/6253077

The "VAGRANT_" prefix also makes it clear in which context they are used.
