### PR TITLE
Ensure the proxies are configured before vagrant-omnibus etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for global `*_proxy` environment variables via `config.env_proxy` ([GH-6][])
 - Configure the VM also on `vagrant provision` ([GH-12][])
     * Hook to all commands that trigger provisioning action
+- Ensure the proxies are configured before [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus) ([GH-13][])
 
 # 0.3.0 / 2013-07-12
 
@@ -39,6 +40,7 @@
 [GH-10]: https://github.com/tmatilai/vagrant-proxyconf/issues/10 "Issue 10"
 [GH-11]: https://github.com/tmatilai/vagrant-proxyconf/issues/11 "Issue 11"
 [GH-12]: https://github.com/tmatilai/vagrant-proxyconf/issues/12 "Issue 12"
+[GH-13]: https://github.com/tmatilai/vagrant-proxyconf/issues/13 "Issue 13"
 [GH-14]: https://github.com/tmatilai/vagrant-proxyconf/issues/14 "Issue 14"
 [GH-15]: https://github.com/tmatilai/vagrant-proxyconf/issues/15 "Issue 15"
 [GH-17]: https://github.com/tmatilai/vagrant-proxyconf/issues/17 "Issue 17"

--- a/lib/vagrant-proxyconf/plugin.rb
+++ b/lib/vagrant-proxyconf/plugin.rb
@@ -39,6 +39,10 @@ module VagrantPlugins
         VagrantPlugins.const_defined?('AWS')
       end
 
+      def self.omnibus_plugin_installed?
+        VagrantPlugins.const_defined?('Omnibus')
+      end
+
       setup_i18n
       check_vagrant_version!
 
@@ -70,10 +74,15 @@ module VagrantPlugins
       end
 
       action_hook 'proxyconf_configure' do |hook|
-        register_hooks(hook, Vagrant::Action::Builtin::Provision)
+        if omnibus_plugin_installed?
+          # configure the proxies before vagrant-omnibus
+          register_hooks(hook, VagrantPlugins::Omnibus::Action::InstallChef)
+        else
+          register_hooks(hook, Vagrant::Action::Builtin::Provision)
 
-        # vagrant-aws uses a non-standard provision action
-        register_hooks(hook, VagrantPlugins::AWS::Action::TimedProvision) if aws_plugin_installed?
+          # vagrant-aws uses a non-standard provision action
+          register_hooks(hook, VagrantPlugins::AWS::Action::TimedProvision) if aws_plugin_installed?
+        end
       end
     end
   end


### PR DESCRIPTION
Try to kick in before other plugins so that the proxy settings would take effect for them, too. This would be especially useful with #6 and e.g. vagrant-omnibus plugin.

Thanks to @tknerr for the idea.
