### PR TITLE
The generated tempfile is sometimes deleted before uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Compatibility with vagrant-aws v0.4.0 ([GH-28][])
     * Next vagrant-aws release [will remove](https://github.com/mitchellh/vagrant-aws/commit/dd17f23) its custom TimedProvision action class
+- Ensure that generated configuration files are not deleted before uploading ([GH-29][])
 
 # 0.5.2 / 2013-09-27
 
@@ -75,3 +76,4 @@
 [GH-26]: https://github.com/tmatilai/vagrant-proxyconf/issues/26 "Issue 26"
 [GH-27]: https://github.com/tmatilai/vagrant-proxyconf/issues/27 "Issue 27"
 [GH-28]: https://github.com/tmatilai/vagrant-proxyconf/issues/28 "Issue 28"
+[GH-29]: https://github.com/tmatilai/vagrant-proxyconf/issues/29 "Issue 29"

--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -72,10 +72,11 @@ module VagrantPlugins
         def write_config(machine, config, opts = {})
           tmp = "/tmp/vagrant-proxyconf"
           path = opts[:path] || config_path(machine)
+          local_tmp = tempfile(config)
 
           logger.debug "Configuration (#{path}):\n#{config}"
           machine.communicate.tap do |comm|
-            comm.upload(tempfile(config).path, tmp)
+            comm.upload(local_tmp.path, tmp)
             comm.sudo("chmod #{opts[:mode] || '0644'} #{tmp}")
             comm.sudo("chown #{opts[:owner] || 'root:root'} #{tmp}")
             comm.sudo("mkdir -p #{File.dirname(path)}")


### PR DESCRIPTION
Recent refactoring (805e857) can lead to situations where the Tempfile is garbage collected and thus the file deleted before uploading to the VM. We have to make sure that the Tempfile stays in the scope long enough.
