### PR TITLE
Remove the destination path before uploading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.0 / _Unreleased_
 
 - Add support for configuring Yum directly (not only via global env vars) ([GH-4][])
+- Remove the target path before uploading files to VM to avoid permission problems ([GH-32][])
 
 # 0.6.0 / 2013-10-15
 
@@ -87,3 +88,4 @@
 [GH-28]: https://github.com/tmatilai/vagrant-proxyconf/issues/28 "Issue 28"
 [GH-29]: https://github.com/tmatilai/vagrant-proxyconf/issues/29 "Issue 29"
 [GH-30]: https://github.com/tmatilai/vagrant-proxyconf/issues/30 "Issue 30"
+[GH-32]: https://github.com/tmatilai/vagrant-proxyconf/issues/32 "Issue 32"

--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -78,6 +78,7 @@ module VagrantPlugins
 
           logger.debug "Configuration (#{path}):\n#{config}"
           machine.communicate.tap do |comm|
+            comm.sudo("rm #{tmp}", error_check: false)
             comm.upload(local_tmp.path, tmp)
             comm.sudo("chmod #{opts[:mode] || '0644'} #{tmp}")
             comm.sudo("chown #{opts[:owner] || 'root:root'} #{tmp}")

--- a/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
           path = config_path(machine)
 
           machine.communicate.tap do |comm|
+            comm.sudo("rm #{tmp}", error_check: false)
             comm.upload(ProxyConf.resource("yum_config.awk"), tmp)
             comm.sudo("touch #{path}")
             comm.sudo("gawk -f #{tmp} #{proxy_params(config)} #{path} > #{path}.new")


### PR DESCRIPTION
Avoid permission problems in case that the target file exists and the SSH user doesn't have write permissions to it.
