### PR TITLE
Use URI::Generic#select to build proxy string.

### DIFF
--- a/lib/vagrant-proxyconf/userinfo_uri.rb
+++ b/lib/vagrant-proxyconf/userinfo_uri.rb
@@ -30,9 +30,8 @@ module VagrantPlugins
       # @param uri [URI::Generic] the URI with optional userinfo
       # @return [String] the URI without userinfo
       def strip_userinfo(uri)
-        u = uri.dup
-        u.userinfo = ''
-        u.to_s
+        u = uri.normalize.select(:host, :port).join(':').concat(uri.path)
+        [uri.scheme, '//'].join(':').concat(u)
       end
     end
   end


### PR DESCRIPTION
I ran into this separately from issue #36 but it boils down to two
issues:
- Implementation of URI::Generic#to_s omits the port if it equals to the
  default port value (doesn't matter scheme);
- Yum proxy requires the TCP port value irregardless of if it is the
  default port or not.

This would crop up with any software which required the TCP value to be
explicit even know sane implementations would just assume a default
value if one was omitted.
