### PR TITLE
Add setting for disabling the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ For example to spin up a VM, run:
 VAGRANT_HTTP_PROXY="http://proxy.example.com:8080" vagrant up
 ```
 
+### Disabling the plugin
+
+The plugin can be totally skipped by setting `config.proxy.enabled` to `false` or empty string (`""`). This can be useful to for example disable it for some provider.
+
+#### Example Vagrantfile
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.proxy.http = "http://192.168.0.2:3128/"
+
+  config.vm.provider :my_cloud do |cloud, override|
+    override.proxy.enabled = false
+  end
+  # ... other stuff
+end
+```
+
 ### Global `*_proxy` environment variables
 
 Many programs (wget, curl, yum, etc.) can be configured to use proxies with `http_proxy` or `HTTP_PROXY` etc. environment variables. This configuration will be written to _/etc/profile.d/proxy.sh_ on the guest.

--- a/lib/vagrant-proxyconf/action.rb
+++ b/lib/vagrant-proxyconf/action.rb
@@ -1,7 +1,9 @@
+require 'vagrant/action/builtin/call'
 require_relative 'action/configure_apt_proxy'
 require_relative 'action/configure_chef_proxy'
 require_relative 'action/configure_env_proxy'
 require_relative 'action/configure_yum_proxy'
+require_relative 'action/is_enabled'
 require_relative 'action/only_once'
 
 module VagrantPlugins
@@ -22,10 +24,14 @@ module VagrantPlugins
       #   middleware builder
       def self.config_actions
         @actions ||= Proc.new do |builder|
-          builder.use ConfigureAptProxy
-          builder.use ConfigureChefProxy
-          builder.use ConfigureEnvProxy
-          builder.use ConfigureYumProxy
+          builder.use Vagrant::Action::Builtin::Call, IsEnabled do |env, b2|
+            next if !env[:result]
+
+            b2.use ConfigureAptProxy
+            b2.use ConfigureChefProxy
+            b2.use ConfigureEnvProxy
+            b2.use ConfigureYumProxy
+          end
         end
       end
     end

--- a/lib/vagrant-proxyconf/action/is_enabled.rb
+++ b/lib/vagrant-proxyconf/action/is_enabled.rb
@@ -1,0 +1,24 @@
+module VagrantPlugins
+  module ProxyConf
+    class Action
+      # Action which checks if the plugin should be enabled
+      class IsEnabled
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:result] = plugin_enabled?(env[:machine].config.proxy)
+
+          @app.call(env)
+        end
+
+        private
+
+        def plugin_enabled?(config)
+          config.enabled != false && config.enabled != ''
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-proxyconf/config/proxy.rb
+++ b/lib/vagrant-proxyconf/config/proxy.rb
@@ -11,6 +11,9 @@ module VagrantPlugins
         include KeyMixin
         # @!parse extend KeyMixin::ClassMethods
 
+        # Defines the mode of the plugin
+        key :enabled, env_var: 'VAGRANT_PROXY'
+
         # @return [String] the HTTP proxy
         key :http, env_var: 'VAGRANT_HTTP_PROXY'
 

--- a/spec/unit/vagrant-proxyconf/action/is_enabled_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/is_enabled_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'vagrant-proxyconf/action/is_enabled'
+
+describe VagrantPlugins::ProxyConf::Action::IsEnabled do
+  let(:app) { lambda { |env| } }
+  let(:env) { { :machine => machine } }
+  let(:machine) do
+    double('machine').tap { |machine| machine.stub(:config).and_return(config) }
+  end
+  let(:config) do
+    double('config').tap { |config| config.stub(:proxy => proxy_config) }
+  end
+  let(:proxy_config) do
+    double('proxy_config').tap { |config| config.stub(:enabled => enabled) }
+  end
+
+  [false, ''].each do |value|
+    context "with `config.proxy.enabled=#{value.inspect}`" do
+      let(:enabled) { value }
+
+      it "results to falsy" do
+        described_class.new(app, {}).call(env)
+        expect(env[:result]).to be_false
+      end
+    end
+  end
+
+  [nil, true, :auto, 'yes please'].each do |value|
+    context "with `config.proxy.enabled=#{value.inspect}`" do
+      let(:enabled) { value }
+
+      it "results to truthy" do
+        described_class.new(app, {}).call(env)
+        expect(env[:result]).to be_true
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The plugin can be totally skipped by setting `config.proxy.enabled` to `false` or empty string (`""`). This can be useful to for example disable it for some provider.

This also a step closer to auto-detection (#38), but I found it better to make separate pull requests of them. Especially as I haven't decided all the details about the latter yet. ;)

Reviews, testing, comments, etc. welcome as always.
