### PR TITLE
Add support for npm proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin can set:
 * generic `http_proxy` etc. environment variables that many programs support
 * default proxy configuration for all Chef provisioners
 * proxy configuration for Apt
+* proxy configuration for npm
 * proxy configuration for Yum
 * proxy configuration for PEAR
 

--- a/lib/vagrant-proxyconf/action.rb
+++ b/lib/vagrant-proxyconf/action.rb
@@ -3,6 +3,7 @@ require_relative 'action/configure_apt_proxy'
 require_relative 'action/configure_chef_proxy'
 require_relative 'action/configure_env_proxy'
 require_relative 'action/configure_git_proxy'
+require_relative 'action/configure_npm_proxy'
 require_relative 'action/configure_pear_proxy'
 require_relative 'action/configure_svn_proxy'
 require_relative 'action/configure_yum_proxy'
@@ -32,6 +33,7 @@ module VagrantPlugins
             next if !env[:result]
 
             b2.use ConfigureGitProxy
+            b2.use ConfigureNpmProxy
             b2.use ConfigurePearProxy
             b2.use ConfigureSvnProxy
           end
@@ -51,6 +53,7 @@ module VagrantPlugins
             b2.use ConfigureChefProxy
             b2.use ConfigureEnvProxy
             b2.use ConfigureGitProxy
+            b2.use ConfigureNpmProxy
             b2.use ConfigurePearProxy
             b2.use ConfigureSvnProxy
             b2.use ConfigureYumProxy

--- a/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
@@ -1,0 +1,36 @@
+require_relative 'base'
+
+module VagrantPlugins
+  module ProxyConf
+    class Action
+      # Action for configuring npm on the guest
+      class ConfigureNpmProxy < Base
+        def config_name
+          'npm_proxy'
+        end
+
+        private
+
+        # @return [Vagrant::Plugin::V2::Config] the configuration
+        def config
+          # Use global proxy config
+          @config ||= finalize_config(@machine.config.proxy)
+        end
+
+        def configure_machine
+          set_or_delete_proxy('proxy', config.http)
+          set_or_delete_proxy('https-proxy', config.https)
+        end
+
+        def set_or_delete_proxy(key, value)
+          if value
+            command = "npm config set #{key} #{escape(config.http)}"
+          else
+            command = "npm config delete #{key}"
+          end
+          @machine.communicate.sudo(command)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-proxyconf/cap/linux/npm_proxy_conf.rb
+++ b/lib/vagrant-proxyconf/cap/linux/npm_proxy_conf.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module ProxyConf
+    module Cap
+      module Linux
+        # Capability for npm proxy configuration
+        module NpmProxyConf
+          # @return [Boolean] if npm is installed
+          def self.npm_proxy_conf(machine)
+            machine.communicate.test('which npm')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-proxyconf/capability.rb
+++ b/lib/vagrant-proxyconf/capability.rb
@@ -22,6 +22,11 @@ module VagrantPlugins
         Cap::Linux::GitProxyConf
       end
 
+      guest_capability 'linux', 'npm_proxy_conf' do
+        require_relative 'cap/linux/npm_proxy_conf'
+        Cap::Linux::NpmProxyConf
+      end
+
       guest_capability 'linux', 'pear_proxy_conf' do
         require_relative 'cap/linux/pear_proxy_conf'
         Cap::Linux::PearProxyConf

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,6 +24,14 @@ en:
       configuring: |-
         Configuring proxy environment variables...
 
+    npm_proxy:
+      not_enabled: |-
+        npm_proxy not enabled or configured
+      not_supported: |-
+        Skipping npm proxy config as `npm` is not found
+      configuring: |-
+        Configuring proxy for npm...
+
     pear_proxy:
       not_enabled: |-
         pear_proxy not enabled or configured

--- a/spec/unit/vagrant-proxyconf/action/configure_npm_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/configure_npm_proxy_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'vagrant-proxyconf/action/configure_npm_proxy'
+
+describe VagrantPlugins::ProxyConf::Action::ConfigureNpmProxy do
+
+  describe '#config_name' do
+    subject { described_class.new(double, double).config_name }
+    it      { should eq 'npm_proxy' }
+  end
+end

--- a/spec/unit/vagrant-proxyconf/cap/linux/npm_proxy_conf_spec.rb
+++ b/spec/unit/vagrant-proxyconf/cap/linux/npm_proxy_conf_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'vagrant-proxyconf/cap/linux/npm_proxy_conf'
+
+describe VagrantPlugins::ProxyConf::Cap::Linux::NpmProxyConf do
+
+  describe '.npm_proxy_conf' do
+    let(:machine) { double }
+    let(:communicator) { double }
+
+    before do
+      machine.stub(:communicate => communicator)
+    end
+
+    it "returns true when npm is installed" do
+      expect(communicator).to receive(:test).with('which npm').and_return(true)
+      expect(described_class.npm_proxy_conf(machine)).to be_true
+    end
+
+    it "returns false when npm is not installed" do
+      expect(communicator).to receive(:test).with('which npm').and_return(false)
+      expect(described_class.npm_proxy_conf(machine)).to be_false
+    end
+  end
+
+end


### PR DESCRIPTION
Configure npm to use proxies if it is installed.

While the [docs](https://www.npmjs.org/doc/misc/npm-config.html) says they would use to env vars, but the [code](https://github.com/npm/npm/blob/v1.4.3/lib/utils/fetch.js#L76-L79) and issues suggest otherwise.
So we use `npm config set/delete`. And hook also after each provisioner run.

Fixes #50
