### PR TITLE
Configure Proxy Before not After Omnibus

### DIFF
--- a/lib/vagrant-proxyconf/hook.rb
+++ b/lib/vagrant-proxyconf/hook.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
 
         # configure the proxies before vagrant-omnibus
         if defined?(VagrantPlugins::Omnibus::Action::InstallChef)
-          hook.after VagrantPlugins::Omnibus::Action::InstallChef, Action.configure
+          hook.before VagrantPlugins::Omnibus::Action::InstallChef, Action.configure
         end
 
         # configure the proxies before vagrant-vbguest


### PR DESCRIPTION
Was trying to get the vagrant-omnibus plugin working behind a corporate proxy today and it was working fine for everything else but timing out for the omnibus plugin.  I'm very new to ruby/vagrant/etc but I'm thinking this is the reason.

Thanks for all your work, this plugin has cured almost all my proxy headaches.
