### PR TITLE
Use HTTPS git address for firewall issues.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'vagrant',
-  github: 'mitchellh/vagrant',
+  git: 'https://github.com/mitchellh/vagrant',
   ref: ENV.fetch('VAGRANT_VERSION', 'v1.4.3')
 
 gem 'cane', '~> 2.6'


### PR DESCRIPTION
For those of us behind firewall using the git protocol (default in older
versions of bundler) is no bueno. Unfortunately, as far as I know, only
in the latest version can we actually specify the protocol to use with
the :github syntax in the Gemfile.
