### PR TITLE
Fix npm HTTPS proxy value

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
 
         def set_or_delete_proxy(key, value)
           if value
-            command = "npm config set #{key} #{escape(config.http)}"
+            command = "npm config set #{key} #{escape(value)}"
           else
             command = "npm config delete #{key}"
           end


### PR DESCRIPTION
The `https-proxy` npm config was defined using `config.http` proxyconf value (missing the `s`), which is wrong.
