### PR TITLE
Enable CoreOS support again now that root partition can be written to

### DIFF
--- a/lib/vagrant-proxyconf/capability.rb
+++ b/lib/vagrant-proxyconf/capability.rb
@@ -8,10 +8,6 @@ module VagrantPlugins
         Cap::Debian::AptProxyConf
       end
 
-      guest_capability 'coreos', 'env_proxy_conf' do
-        # disabled on CoreOS
-      end
-
       guest_capability 'linux', 'env_proxy_conf' do
         require_relative 'cap/linux/env_proxy_conf'
         Cap::Linux::EnvProxyConf


### PR DESCRIPTION
As @tmatilai commented in coreos/coreos-vagrant#30, recent (later than 286.0) versions of CoreOS features a writable root partition, allowing to set environment variables in `/etc/profile.d` (and other places). This pull request undoes #35 and enable the plugin again for CoreOS hosts.
