### PR TITLE
Delete docker configration after provision

### DIFF
--- a/lib/vagrant-proxyconf/action.rb
+++ b/lib/vagrant-proxyconf/action.rb
@@ -33,7 +33,6 @@ module VagrantPlugins
           b.use Builtin::Call, IsEnabled do |env, b2|
             next if !env[:result]
 
-            b2.use ConfigureDockerProxy
             b2.use ConfigureGitProxy
             b2.use ConfigureNpmProxy
             b2.use ConfigurePearProxy


### PR DESCRIPTION
This pull-request is for fixing the issue #72.

This pull-request makes vagrant-proxyconf do docker proxy config only once at the beginning of the provision. 

The old version does docker proxy config twice at beginning of a provision and after the provision. If vagrant-proxyconf does docker proxy config after a provision, docker can fail to restart the daemon. Docker can take effect with only a configuration at the beginning of the provision.

We have checked this pull-request working well on:
- [X] RHEL
- [X] Ubuntu
- [X] boot2docker by @dduportal, thank you.

---

There are remaining problem(s).
-  [X] vagrant-proxyconf can not take effect if docker installation in provision phase.
  - I am going to close this phenomenon as a limitation. 
