### PR TITLE
Add docker RHEL7 support

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
@@ -49,7 +49,7 @@ module VagrantPlugins
             comm.sudo("chown root:root #{path}.new")
             comm.sudo("mv #{path}.new #{path}")
             comm.sudo("rm #{tmp}")
-            comm.sudo("service #{docker} restart || /etc/init.d/#{docker} restart")
+            comm.sudo(service_restart_command)
           end
         end
 
@@ -57,6 +57,12 @@ module VagrantPlugins
           @machine.communicate.tap do |comm|
             comm.test('which systemctl') ? @export = '' : @export = 'export '
           end
+        end
+
+        def service_restart_command
+          ["systemctl restart #{docker}",
+            "service #{docker} restart",
+            "/etc/init.d/#{docker} restart"].join(' || ')
         end
 
         def docker_sed_script


### PR DESCRIPTION
<del> This is a work in progress. </del>

I have found that vagrant-proxyconf docker support does not work on RHEL 7.
- On RHEL 6:
  -  docker proxy config is in `/etc/sysconfig/docker` and it is 'called' from [init](https://github.com/dotcloud/docker/blob/b9f66049fa4d0dc2cdc0a430fe14029214456611/contrib/init/sysvinit-redhat/docker#L31).
  - it should be `export http_proxy=http://myproxy:3128/`
- On RHEL 7:
  - docker proxy config is in `/etc/sysconfig/docker` but it is not 'called' but just 'evaluated' by systemctl.
  - it should be `http_proxy=http://myproxy:3128/`

I need to do:
- [x] implementation
- [x] tests
  - [x] CentOS 7.0
  - [x] CentOS 6.5
  - [x] Ubuntu 14.04
  - [x] boot2docker

---

On my Mac I tested with this [Vagrantfile](https://gist.github.com/otahi/25021510386a12e765bd).
(I had already installed some boxes)

Then I have got the result, that means dockers have correct `http_proxy` environment value.

```
$ for vm in centos7 centos6 ubuntu14.04 boot2docker ; do echo -n $vm, ; vagrant ssh $vm -c 'sudo cat /proc/`pgrep docker|head -n1`/environ | grep -c http_proxy' 2&> /dev/null ; done
centos7,1
centos6,1
ubuntu14.04,1
boot2docker,1
$
```
