### PR TITLE
Under OpenBSD, the group of `root` is `wheel`.

### DIFF
--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -82,7 +82,7 @@ module VagrantPlugins
             comm.sudo("rm #{tmp}", error_check: false)
             comm.upload(local_tmp.path, tmp)
             comm.sudo("chmod #{opts[:mode] || '0644'} #{tmp}")
-            comm.sudo("chown #{opts[:owner] || 'root:root'} #{tmp}")
+            comm.sudo("chown #{opts[:owner] || 'root'} #{tmp}")
             comm.sudo("mkdir -p #{File.dirname(path)}")
             comm.sudo("mv #{tmp} #{path}")
           end

--- a/lib/vagrant-proxyconf/action/configure_env_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_env_proxy.rb
@@ -65,7 +65,7 @@ module VagrantPlugins
             comm.sudo("sed -e '#{sed_script}' #{path} > #{path}.new")
             comm.sudo("cat #{tmp} >> #{path}.new")
             comm.sudo("chmod 0644 #{path}.new")
-            comm.sudo("chown root:root #{path}.new")
+            comm.sudo("chown root #{path}.new")
             comm.sudo("mv #{path}.new #{path}")
             comm.sudo("rm #{tmp}")
           end


### PR DESCRIPTION
Working with this (dirty) patch.

I set up a local Squid proxy on my workstation (`10.0.0.6`), and used this Vagrantfile:

``` ruby
Vagrant.configure("2") do |config|
  config.vm.box = "tmatilai/openbsd-5.5"
  config.ssh.shell = '/bin/sh -l'
  config.vm.synced_folder ".", "/vagrant", type: :rsync
  config.vm.provision "shell", inline: "echo hello"

  if Vagrant.has_plugin?("vagrant-proxyconf")
    config.proxy.http = "http://10.0.0.6:3128"
    config.proxy.https = "http://10.0.0.6:3128"
    config.proxy.ftp = "http://10.0.0.6:3128"
    config.proxy.no_proxy = "localhost,127.0.0.1"
  end
end
```

The command `vagrant up` worked this time:

```
$ vagrant up
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...
==> default: Running cleanup tasks for 'shell' provisioner...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'tmatilai/openbsd-5.5'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'tmatilai/openbsd-5.5' is up to date...
==> default: Setting the name of the VM: vagrant-openbsd_default_1407519783680_98398
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2222 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default: 
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Configuring proxy environment variables...
==> default: Installing rsync to the VM...
==> default: Rsyncing folder: /home/carlos/src/vagrant-openbsd/ => /vagrant
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: hello
$ 
```

The variables are set:

```
$ vagrant ssh -c "cat /etc/profile"
export HTTP_PROXY=http://marcelino.lan:3128
export http_proxy=http://marcelino.lan:3128
export HTTPS_PROXY=http://marcelino.lan:3128
export https_proxy=http://marcelino.lan:3128
export FTP_PROXY=http://marcelino.lan:3128
export ftp_proxy=http://marcelino.lan:3128
export NO_PROXY="localhost,127.0.0.1"
export no_proxy="localhost,127.0.0.1"
Connection to 127.0.0.1 closed.
$
```

In `/var/log/squid3/access.log`:

```
1407518822.905   2563 10.0.0.6 TCP_MISS/200 1162647 GET http://ftp.openbsd.org/pub/OpenBSD/5.5/packages/amd64/ - HIER_DIRECT/129.128.5.191 text/html
1407518823.127    149 10.0.0.6 TCP_MISS/200 6690 GET http://ftp.openbsd.org/pub/OpenBSD/5.5/packages/amd64/quirks-1.113.tgz - HIER_DIRECT/129.128.5.191 application/x-tar
1407518824.084    891 10.0.0.6 TCP_MISS/200 282891 GET http://ftp.openbsd.org/pub/OpenBSD/5.5/packages/amd64/rsync-3.1.0.tgz - HIER_DIRECT/129.128.5.191 application/x-tar
```

`vagrant provision` also works:

```
carlos@marcelino:~/src/vagrant-openbsd$ vagrant provision
==> default: Configuring proxy environment variables...
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: hello
carlos@marcelino:~/src/vagrant-openbsd$ 
``

The line `config.ssh.shell = '/bin/sh -l'` is needed: Without it, I see no hits in Squid's access log
```
