### PR TITLE
ignore aliases for different commands

### DIFF
--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -79,12 +79,12 @@ module VagrantPlugins
 
           logger.debug "Configuration (#{path}):\n#{config}"
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{tmp}", error_check: false)
+            comm.sudo("rm -f #{tmp}", error_check: false)
             comm.upload(local_tmp.path, tmp)
             comm.sudo("chmod #{opts[:mode] || '0644'} #{tmp}")
             comm.sudo("chown #{opts[:owner] || 'root:root'} #{tmp}")
             comm.sudo("mkdir -p #{File.dirname(path)}")
-            comm.sudo("mv #{tmp} #{path}")
+            comm.sudo("mv -f #{tmp} #{path}")
           end
         end
 

--- a/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
@@ -40,15 +40,15 @@ module VagrantPlugins
             sed_script = docker_sed_script
             local_tmp = tempfile(docker_config)
 
-            comm.sudo("rm #{tmp}", error_check: false)
+            comm.sudo("rm -f #{tmp}", error_check: false)
             comm.upload(local_tmp.path, tmp)
             comm.sudo("touch #{path}")
             comm.sudo("sed -e '#{sed_script}' #{path} > #{path}.new")
             comm.sudo("cat #{tmp} >> #{path}.new")
             comm.sudo("chmod 0644 #{path}.new")
             comm.sudo("chown root:root #{path}.new")
-            comm.sudo("mv #{path}.new #{path}")
-            comm.sudo("rm #{tmp}")
+            comm.sudo("mv -f #{path}.new #{path}")
+            comm.sudo("rm -f #{tmp}")
             comm.sudo(service_restart_command)
           end
         end

--- a/lib/vagrant-proxyconf/action/configure_env_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_env_proxy.rb
@@ -59,15 +59,15 @@ module VagrantPlugins
           local_tmp = tempfile(environment_config)
 
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{tmp}", error_check: false)
+            comm.sudo("rm -f #{tmp}", error_check: false)
             comm.upload(local_tmp.path, tmp)
             comm.sudo("touch #{path}")
             comm.sudo("sed -e '#{sed_script}' #{path} > #{path}.new")
             comm.sudo("cat #{tmp} >> #{path}.new")
             comm.sudo("chmod 0644 #{path}.new")
             comm.sudo("chown root:root #{path}.new")
-            comm.sudo("mv #{path}.new #{path}")
-            comm.sudo("rm #{tmp}")
+            comm.sudo("mv -f #{path}.new #{path}")
+            comm.sudo("rm -f #{tmp}")
           end
         end
 

--- a/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
@@ -18,14 +18,14 @@ module VagrantPlugins
           path = config_path
 
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{tmp}", error_check: false)
+            comm.sudo("rm -f #{tmp}", error_check: false)
             comm.upload(ProxyConf.resource("yum_config.awk"), tmp)
             comm.sudo("touch #{path}")
             comm.sudo("gawk -f #{tmp} #{proxy_params} #{path} > #{path}.new")
             comm.sudo("chmod 0644 #{path}.new")
             comm.sudo("chown root:root #{path}.new")
-            comm.sudo("mv #{path}.new #{path}")
-            comm.sudo("rm #{tmp}")
+            comm.sudo("mv -f #{path}.new #{path}")
+            comm.sudo("rm -f #{tmp}")
           end
         end
 

--- a/lib/vagrant-proxyconf/cap/coreos/docker_proxy_conf.rb
+++ b/lib/vagrant-proxyconf/cap/coreos/docker_proxy_conf.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               env_file='EnvironmentFile=-\/etc\/default\/docker'
               comm.sudo("sed -e 's/\\[Service\\]/[Service]\\n#{env_file}/g' #{src_file} > #{tmp_file}")
 
-              comm.sudo('mv /tmp/docker.service /etc/systemd/system/')
+              comm.sudo('mv -f /tmp/docker.service /etc/systemd/system/')
               comm.sudo('systemctl daemon-reload')
             end
             '/etc/default/docker'


### PR DESCRIPTION
Hi, 

i had the problem that e.g. CentOS6 sets some aliases for mv, rm and cp to use -i (interactive).
In this case, the plugin doesn't work properly. It seems to wait forever. 
I simply added a backslash in front of the commands, which ignores aliases.

Regards,
Sascha
