### PR TITLE
Perform system-wide NPM proxy configuration

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_npm_proxy.rb
@@ -23,15 +23,15 @@ module VagrantPlugins
         end
 
         def set_or_delete_proxy(key, value)
-          command = "#{npm_path} config "
+          command = "#{npm_path} config --global "
           if value
             command << "set #{key} #{escape(value)}"
           else
             command << "delete #{key}"
 
-            # ensure that the .npmrc file exists to work around
+            # ensure that the npmrc file exists to work around
             # https://github.com/npm/npm/issues/5065
-            @machine.communicate.sudo("touch ~/.npmrc")
+            @machine.communicate.sudo("#{npm_path} config --global set #{key} foo")
           end
           @machine.communicate.sudo(command)
         end


### PR DESCRIPTION
This pull request fixes #89. It uses the `--global` option of npm config which places the proxy configurations in the system wide configuration file. Tested on Ubuntu 14.04.
