### PR TITLE
Don't fail if removing non-existing git proxy configuration

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_git_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_git_proxy.rb
@@ -21,13 +21,14 @@ module VagrantPlugins
         end
 
         def configure_machine
-          command = "#{git_path} config --system "
           if config.http
-            command << "http.proxy #{config.http}"
+            @machine.communicate.sudo(
+              "#{git_path} config --system http.proxy #{config.http}")
           else
-            command << "--unset-all http.proxy"
+            @machine.communicate.sudo(
+              "#{git_path} config --system --unset-all http.proxy",
+              error_check: false)
           end
-          @machine.communicate.sudo(command)
         end
 
         def git_path


### PR DESCRIPTION
Calling `git config --unset-all` for non-existing keys exits with non-zero exit code. We just ignore all the errors here.

Ref: https://github.com/tmatilai/vagrant-proxyconf/pull/93#issuecomment-65002589
