### PR TITLE
Fix docker incompleted refactoring(missing parameter)

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
@@ -45,12 +45,12 @@ module VagrantPlugins
             comm.sudo("touch #{path}")
             comm.sudo("sed -e '#{sed_script}' #{path} > #{path}.new")
             comm.sudo("cat #{tmp} >> #{path}.new")
-            update_config(path)
+            update_config(comm, path)
             comm.sudo("rm -f #{tmp} #{path}.new")
           end
         end
 
-        def update_config(path)
+        def update_config(comm, path)
           return if comm.test("diff #{path}.new #{path}")
 
           # update config and restart docker when config changed


### PR DESCRIPTION
I have committed incompleted source code. I missed a commit to fix the problem on #92.
I have confirmed it works.

```
[otahi@otahiair vagrant-proxyconf-test]$ vagrant reload centos6
==> centos6: Attempting graceful shutdown of VM...
==> centos6: Clearing any previously set forwarded ports...
==> centos6: Clearing any previously set network interfaces...
==> centos6: Preparing network interfaces based on configuration...
    centos6: Adapter 1: nat
==> centos6: Forwarding ports...
    centos6: 22 => 2222 (adapter 1)
==> centos6: Booting VM...
==> centos6: Waiting for machine to boot. This may take a few minutes...
    centos6: SSH address: 127.0.0.1:2222
    centos6: SSH username: vagrant
    centos6: SSH auth method: private key
    centos6: Warning: Remote connection disconnect. Retrying...
==> centos6: Machine booted and ready!
==> centos6: Configuring proxy for Docker...
==> centos6: Configuring proxy environment variables...
==> centos6: Configuring proxy for Yum...
==> centos6: Checking for guest additions in VM...
==> centos6: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> centos6: to force provisioning. Provisioners marked to run always will still run.
[otahi@otahiair vagrant-proxyconf-test]$
```
