### PR TITLE
Run configuration for docker after provisioning

### DIFF
--- a/lib/vagrant-proxyconf/action.rb
+++ b/lib/vagrant-proxyconf/action.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
           b.use Builtin::Call, IsEnabled do |env, b2|
             next if !env[:result]
 
+            b2.use ConfigureDockerProxy
             b2.use ConfigureGitProxy
             b2.use ConfigureNpmProxy
             b2.use ConfigurePearProxy


### PR DESCRIPTION
I have changed to run configuration for docker after provisioning to solve #98.

I have tested with this.

Vagrantfile

``` ruby
# -*- mode: ruby -*-
VAGRANTFILE_API_VERSION = '2'

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  if Vagrant.has_plugin?('vagrant-proxyconf')
    config.proxy.http     = 'http://10.0.2.2:3128/'
    config.proxy.https    = 'http://10.0.2.2:3128/'
    config.proxy.enabled  = true
  end

  config.vm.synced_folder './', '/vagrant', disabled: true

  config.vm.define 'centos7' do |c|
    c.vm.box = 'hfm4/centos7'
    c.vm.provision "docker"
  end
end
```

Log

```
[otahi@otahiair vagrant-proxyconf-test]$ vagrant up centos7
Bringing machine 'centos7' up with 'virtualbox' provider...
==> centos7: Importing base box 'hfm4/centos7'...
:
:
==> centos7: Machine booted and ready!
==> centos7: Configuring proxy environment variables...
==> centos7: Configuring proxy for Yum...
:
:
==> centos7: Running provisioner: docker...
    centos7: Installing Docker (latest) onto machine...
    centos7: Configuring Docker to autostart containers...
==> centos7: Configuring proxy for Docker...
[otahi@otahiair vagrant-proxyconf-test]$
```

Test

```
[otahi@otahiair vagrant-proxyconf-test]$ vagrant ssh centos7 -c 'sudo cat /proc/`pgrep docker|head -n1`/environ'
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/binLANG=en_US.UTF-8NOTIFY_SOCKET=@/org/freedesktop/systemd1/notifyLISTEN_PID=5635LISTEN_FDS=1OPTIONS=--selinux-enabled -H fd://HTTP_PROXY=http://10.0.2.2:3128/NO_PROXY=http_proxy=http://10.0.2.2:3128/no_proxy=DOCKER_STORAGE_OPTIONS=Connection to 127.0.0.1 closed.
[otahi@otahiair vagrant-proxyconf-test]$
```
