### PR TITLE
Fix Git description to make base conf be N/A

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ SVN configuration is not set if no SVN specific configuration.
 |  Application           | Base conf.     | Specific conf.      | Env. var.     |
 | -----------------------|----------------|---------------------|---------------|
 | configure_apt_proxy    | config.proxy.* | config.apt_proxy.*  | VAGRANT_APT_* |
-| configure_git_proxy    | config.proxy.* | config.git_proxy.*  | VAGRANT_GIT_* |
+| configure_git_proxy    | N/A            | config.git_proxy.*  | VAGRANT_GIT_* |
 | configure_svn_proxy    | N/A            | config.svn_proxy.*  | VAGRANT_SVN_* |
 | configure_yum_proxy    | config.proxy.* | config.yum_proxy.*  | VAGRANT_YUM_* |
 


### PR DESCRIPTION
I have corrected the incorrect description for Git.

---
## Before

| Application | Base conf. | Specific conf. | Env. var. |
| --- | --- | --- | --- |
| configure_apt_proxy | config.proxy.* | config.apt_proxy.* | VAGRANT_APT_* |
| configure_git_proxy | config.proxy.* | config.git_proxy.* | VAGRANT_GIT_* |
| configure_svn_proxy | N/A | config.svn_proxy.* | VAGRANT_SVN_* |
| configure_yum_proxy | config.proxy.* | config.yum_proxy.* | VAGRANT_YUM_* |

:arrow_down: 
## After

| Application | Base conf. | Specific conf. | Env. var. |
| --- | --- | --- | --- |
| configure_apt_proxy | config.proxy.* | config.apt_proxy.* | VAGRANT_APT_* |
| configure_git_proxy | N/A | config.git_proxy.* | VAGRANT_GIT_* |
| configure_svn_proxy | N/A | config.svn_proxy.* | VAGRANT_SVN_* |
| configure_yum_proxy | config.proxy.* | config.yum_proxy.* | VAGRANT_YUM_* |

---

[configure_git_proxy.rb#L18](https://github.com/tmatilai/vagrant-proxyconf/blob/master/lib/vagrant-proxyconf/action/configure_git_proxy.rb#L18)

``` ruby
        # @return [Vagrant::Plugin::V2::Config] the configuration
        def config
          return @config if @config

          # Use only `config.git_proxy`, don't merge with the default config
          @config = @machine.config.git_proxy
          finalize_config(@config)
        end
```
