### PR TITLE
Add cache and sudo configuration for faster build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+sudo: false
 
 before_install:
   - rvm @global do gem uninstall bundler --all --executables


### PR DESCRIPTION
I have changed .travis.yml for faster build on Travis CI according to [Faster Builds with Container-Based Infrastructure and Docker](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/)

This change seems to make a build faster.
![travis-buildtime](https://cloud.githubusercontent.com/assets/1556477/5551136/3b7b0234-8c00-11e4-8618-f416e244cb35.png)
