### PR TITLE
Detect chef provisioners by type instead of by name (multi-machine), fix #101

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
@@ -44,7 +44,12 @@ module VagrantPlugins
         # @return [Array] all Chef provisioners
         def chef_provisioners
           @machine.config.vm.provisioners.select do |prov|
-            [:chef_solo, :chef_client].include?(prov.type)
+            # Since Vagrant > 1.7 the provisioner type is returned by the prov#type method
+            # (it used to be prov#name in older versions). Vagrant 1.7.0 broke prov#name
+            # so we rely on prov#type when possible and fallback to prov#name when not.
+            # See github issues #101 and mitchellh/vagrant#5069.
+            prov_type_method = [:type, :name].detect { |meth| prov.respond_to?(meth) }
+            [:chef_solo, :chef_client].include?(prov.public_send(prov_type_method))
           end
         end
 

--- a/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
         # @return [Array] all Chef provisioners
         def chef_provisioners
           @machine.config.vm.provisioners.select do |prov|
-            [:chef_solo, :chef_client].include?(prov.name)
+            [:chef_solo, :chef_client].include?(prov.type)
           end
         end
 


### PR DESCRIPTION
@tmatilai, here is my modest attempt at fixing #101 (where chef provisioner detection was broken in multi-machine Vagrantfiles). I have tested by hand that the PR works in both single-machine and multi-machine modes, with the following `Vagrantfile`:

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  # Every Vagrant virtual environment requires a box to build off of.
  config.vm.box      = 'opscode-ubuntu-14.04-chef'
  config.vm.box_url  = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box'

  provision = lambda { |chef|
    chef.add_recipe "apt::default"
  }

  if String(ENV['MULTIVM']) == 'true'
    config.vm.define "multi" do |machine|
      machine.vm.hostname = 'multi'
      config.vm.provision(:chef_solo, &provision)
    end
  else
    config.vm.hostname = 'single'
    config.vm.provision(:chef_solo, &provision)
  end
end

```

In single-machine mode:

```sh
jp440p:u $ MULTIVM=true vagrant ssh -- 'hostname && grep no_proxy /tmp/vagrant-chef-*/solo.rb'
multi
no_proxy "localhost,127.0.0.1,172.17.42.1,10.0.3.1,192.168.56.1,192.168.33.1,192.168.122.1,192.168.33.1,192.168.33.10.xip.io,192.168.33.10.xip.io:81"
```

In multi-machine mode:

```sh
jp440p:u $ MULTIVM=false vagrant ssh -- 'hostname && grep no_proxy /tmp/vagrant-chef-*/solo.rb'
single
no_proxy "localhost,127.0.0.1,172.17.42.1,10.0.3.1,192.168.56.1,192.168.33.1,192.168.122.1,192.168.33.1,192.168.33.10.xip.io,192.168.33.10.xip.io:81"
```

(without the PR, it would return `nil` as the value of the chef no_proxy in the multi-vm case).

Feel free to merge, close #101 and enjoy Christmas @tmatilai.