### PR TITLE
Add support for the chef_zero provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
   - Ignore specific applications by passing a hash to `config.proxy.enabled` ([GH-93][])
+  - Support the `chef_zero` provisioner in Vagrant 1.7+ ([GH-105][])
 
 Improvements:
 
@@ -204,3 +205,4 @@ Bug fixes:
 [GH-93]: https://github.com/tmatilai/vagrant-proxyconf/issues/93 "Issue 93"
 [GH-94]: https://github.com/tmatilai/vagrant-proxyconf/issues/94 "Issue 94"
 [GH-103]: https://github.com/tmatilai/vagrant-proxyconf/issues/103 "Issue 103"
+[GH-105]: https://github.com/tmatilai/vagrant-proxyconf/issues/105 "Issue 105"

--- a/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_chef_proxy.rb
@@ -6,6 +6,10 @@ module VagrantPlugins
     class Action
       # Action for configuring Chef provisioners
       class ConfigureChefProxy
+
+        # Array of Chef provisioner types which include proxy configuration
+        CHEF_PROVISIONER_TYPES = [:chef_client, :chef_solo, :chef_zero]
+
         def initialize(app, env)
           @app = app
         end
@@ -44,12 +48,13 @@ module VagrantPlugins
         # @return [Array] all Chef provisioners
         def chef_provisioners
           @machine.config.vm.provisioners.select do |prov|
-            # Since Vagrant > 1.7 the provisioner type is returned by the prov#type method
-            # (it used to be prov#name in older versions). Vagrant 1.7.0 broke prov#name
-            # so we rely on prov#type when possible and fallback to prov#name when not.
-            # See github issues #101 and mitchellh/vagrant#5069.
-            prov_type_method = [:type, :name].detect { |meth| prov.respond_to?(meth) }
-            [:chef_solo, :chef_client].include?(prov.public_send(prov_type_method))
+            # Vagrant 1.7+ uses #type, earlier versions #name
+            if prov.respond_to?(:type)
+              type = prov.type
+            else
+              type = prov.name
+            end
+            CHEF_PROVISIONER_TYPES.include?(type)
           end
         end
 


### PR DESCRIPTION
This PR configures also the [chef_zero](https://docs.vagrantup.com/v2/provisioning/chef_zero.html) provisioners introduced in Vagrant 1.7.0.

(Note that the `chef_apply` provisioner config does not have proxy keys so we don't include it.)