### PR TITLE
need to decode password for yum.conf

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
@@ -1,6 +1,7 @@
 require_relative 'base'
 require_relative '../resource'
 require_relative '../userinfo_uri'
+require 'uri'
 
 module VagrantPlugins
   module ProxyConf
@@ -31,7 +32,13 @@ module VagrantPlugins
 
         def proxy_params
           u = UserinfoURI.new(config.http)
-          "-v proxy=#{escape(u.uri)} -v user=#{escape(u.user)} -v pass=#{escape(u.pass)}"
+          if !u.pass.nil?
+            pdecode = URI.decode(u.pass)
+          else
+            pdecode = u.pass
+          end
+
+          "-v proxy=#{escape(u.uri)} -v user=#{escape(u.user)} -v pass=#{escape(pdecode)}"
         end
       end
     end

--- a/spec/unit/vagrant-proxyconf/action/configure_yum_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/configure_yum_proxy_spec.rb
@@ -32,8 +32,8 @@ describe VagrantPlugins::ProxyConf::Action::ConfigureYumProxy do
     end
 
     context "with special characters" do
-      let(:http) { %q{http://x*y:a(b@proxy.com:8080} }
-      it { is_expected.to eq %q{-v proxy=http://proxy.com:8080 -v user=x\\*y -v pass=a\\(b} }
+      let(:http) { %q{http://x*y:a(%28b@proxy.com:8080} }
+      it { is_expected.to eq %q{-v proxy=http://proxy.com:8080 -v user=x\\*y -v pass=a\\(\\(b} }
     end
   end
 end


### PR DESCRIPTION
If you have a password with a character like '@', you need to encode your password in URL proxy.
HTTP_PROXY=http://user:encode(password)@proxy_url:proxy_port. 
