### PR TITLE
Add uri encoded user password

### DIFF
--- a/lib/vagrant-proxyconf/userinfo_uri.rb
+++ b/lib/vagrant-proxyconf/userinfo_uri.rb
@@ -11,13 +11,7 @@ module VagrantPlugins
       #   @return [String] the host
       # @!attribute [r] port
       #   @return [String] the port
-      # @!attribute [r] user
-      #   @return [String] the username
-      def_delegators :@uri, :host, :port, :user
-
-      # @!attribute [r] pass
-      #   @return [String] the password
-      def_delegator :@uri, :password, :pass
+      def_delegators :@uri, :host, :port
 
       # @param uri [String] the URI including optional userinfo
       def initialize(uri)
@@ -34,6 +28,18 @@ module VagrantPlugins
         else
           "#{@uri.scheme}://#{host}:#{port}"
         end
+      end
+
+      # @return [String] the username
+      def user
+        return URI.decode(@uri.user) if @uri.user
+        @uri.user
+      end
+
+      # @return [String] the password
+      def pass
+        return URI.decode(@uri.password) if @uri.password
+        @uri.password
       end
 
       alias_method :to_s, :uri

--- a/spec/unit/vagrant-proxyconf/action/configure_chef_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/configure_chef_proxy_spec.rb
@@ -45,6 +45,24 @@ describe VagrantPlugins::ProxyConf::Action::ConfigureChefProxy do
       end
     end
 
+    context "with specified default configurations in URI encoded" do
+      before :each do
+        config.http  = 'http://bar%23:baz%25@foo:1234'
+        config.https = false
+
+        configure_chef
+      end
+
+      it "configures chef" do
+        expect(chef.http_proxy).to  eq 'http://foo:1234'
+        expect(chef.http_proxy_user).to eq 'bar#'
+        expect(chef.http_proxy_pass).to eq 'baz%'
+        expect(chef.https_proxy).to be_nil
+        expect(chef.https_proxy_user).to be_nil
+        expect(chef.https_proxy_pass).to be_nil
+      end
+    end
+
     context "with specified chef configurations" do
       before :each do
         chef.http_proxy = 'http://proxy:8080/'

--- a/spec/unit/vagrant-proxyconf/action/configure_svn_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/configure_svn_proxy_spec.rb
@@ -8,4 +8,83 @@ describe VagrantPlugins::ProxyConf::Action::ConfigureSvnProxy do
     it      { is_expected.to eq 'svn_proxy' }
   end
 
+  describe '#svn_config' do
+    subject do
+      action = described_class.new(nil, nil)
+      allow(action).to receive(:config) { config }
+      action.send(:svn_config)
+    end
+    let(:config) { OpenStruct.new(http: http) }
+    let(:uri_encoded) { false }
+
+    context "with `false`" do
+      let(:http) { false }
+      it do
+        is_expected.to eq <<-CONFIG
+[global]
+http-proxy-host=
+http-proxy-port=
+http-proxy-username=
+http-proxy-password=
+http-proxy-exceptions=
+        CONFIG
+      end
+    end
+
+    context "without userinfo" do
+      let(:http) { 'http://proxy:1234/' }
+      it do
+        is_expected.to eq <<-CONFIG
+[global]
+http-proxy-host=proxy
+http-proxy-port=1234
+http-proxy-username=
+http-proxy-password=
+http-proxy-exceptions=
+        CONFIG
+      end
+    end
+
+    context "with userinfo" do
+      let(:http) { 'http://foo:bar@myproxy:9876' }
+      it do
+        is_expected.to eq <<-CONFIG
+[global]
+http-proxy-host=myproxy
+http-proxy-port=9876
+http-proxy-username=foo
+http-proxy-password=bar
+http-proxy-exceptions=
+        CONFIG
+      end
+    end
+
+    context "with special characters" do
+      let(:http) { %q{http://x*y:a(b@proxy.com:8080} }
+      it do
+        is_expected.to eq <<-CONFIG
+[global]
+http-proxy-host=proxy.com
+http-proxy-port=8080
+http-proxy-username=x*y
+http-proxy-password=a(b
+http-proxy-exceptions=
+        CONFIG
+      end
+    end
+
+    context "with URI encoded special characters" do
+      let(:http) { %q{http://foo%25:abc%23123@proxy.com:8080} }
+      it do
+        is_expected.to eq <<-CONFIG
+[global]
+http-proxy-host=proxy.com
+http-proxy-port=8080
+http-proxy-username=foo%
+http-proxy-password=abc#123
+http-proxy-exceptions=
+        CONFIG
+      end
+    end
+  end
 end

--- a/spec/unit/vagrant-proxyconf/action/configure_yum_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/configure_yum_proxy_spec.rb
@@ -35,5 +35,10 @@ describe VagrantPlugins::ProxyConf::Action::ConfigureYumProxy do
       let(:http) { %q{http://x*y:a(b@proxy.com:8080} }
       it { is_expected.to eq %q{-v proxy=http://proxy.com:8080 -v user=x\\*y -v pass=a\\(b} }
     end
+
+    context "with URI encoded special characters" do
+      let(:http) { %q{http://foo%25:abc%23123@proxy.com:8080} }
+      it { is_expected.to eq %q{-v proxy=http://proxy.com:8080 -v user=foo\% -v pass=abc\#123} }
+    end
   end
 end

--- a/spec/unit/vagrant-proxyconf/userinfo_uri_spec.rb
+++ b/spec/unit/vagrant-proxyconf/userinfo_uri_spec.rb
@@ -95,4 +95,13 @@ describe VagrantPlugins::ProxyConf::UserinfoURI do
     its(:pass) { should be_nil }
   end
 
+  context "with uri_encoded" do
+    let(:uri)          { 'http://foo%25:bar%23123@proxy.example.com:8123/' }
+    its(:to_s)         { should eq 'http://proxy.example.com:8123' }
+    its(:uri)          { should eq 'http://proxy.example.com:8123' }
+    its(:host)         { should eq 'proxy.example.com' }
+    its(:port)         { should eq 8123 }
+    its(:user)         { should eq 'foo%' }
+    its(:pass)         { should eq 'bar#123' }
+  end
 end


### PR DESCRIPTION
To solve the issue "Yum config and URL-encoded auth" #129.
Following code set URI encoded user name and password to yum or chef.

```
if Vagrant.has_plugin?("vagrant-proxyconf")
    config.proxy.http  = "http://user:123%23abc@proxy.example.com:80"
    config.proxy.uri_encoded = true
end
```
=> user: user, password: 123#abc
