### PR TITLE
[WIP]Support systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin can set:
 * generic `http_proxy` etc. environment variables that many programs support
 * default proxy configuration for all Chef provisioners
 * proxy configuration for Apt
+* proxy configuration for Systemd
 * proxy configuration for Docker
 * proxy configuration for Git
 * proxy configuration for npm

--- a/lib/vagrant-proxyconf/action.rb
+++ b/lib/vagrant-proxyconf/action.rb
@@ -1,6 +1,7 @@
 require 'vagrant/action/builtin/call'
 require_relative 'action/configure_apt_proxy'
 require_relative 'action/configure_chef_proxy'
+require_relative 'action/configure_systemd_proxy'
 require_relative 'action/configure_docker_proxy'
 require_relative 'action/configure_env_proxy'
 require_relative 'action/configure_git_proxy'
@@ -33,6 +34,7 @@ module VagrantPlugins
           b.use Builtin::Call, IsEnabled do |env, b2|
             next if !env[:result]
 
+            b2.use ConfigureSystemdProxy
             b2.use ConfigureDockerProxy
             b2.use ConfigureGitProxy
             b2.use ConfigureNpmProxy
@@ -53,6 +55,7 @@ module VagrantPlugins
 
             b2.use ConfigureAptProxy
             b2.use ConfigureChefProxy
+            b2.use ConfigureSystemdProxy
             b2.use ConfigureDockerProxy
             b2.use ConfigureEnvProxy
             b2.use ConfigureGitProxy

--- a/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
@@ -20,7 +20,6 @@ module VagrantPlugins
 
         def configure_machine
           logger.info('Writing the proxy configuration to systemd config')
-          detect_export
           write_systemd_config
         end
 
@@ -33,12 +32,6 @@ module VagrantPlugins
               comm.sudo(service_restart_command_low)
               comm.sudo(service_restart_command_up)
             end
-          end
-        end
-
-        def detect_export
-          @machine.communicate.tap do |comm|
-            comm.test('which systemctl') ? @export = '' : @export = 'export '
           end
         end
 

--- a/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
@@ -44,7 +44,10 @@ module VagrantPlugins
         def reflect_config
           return unless @restart_needed
           @machine.ui.info(I18n.t("#{I18N_PREFIX}restarting_guest_start"))
-          @machine.communicate.sudo('shutdown -r now')
+          begin timeout(10) { @machine.communicate.sudo('shutdown -r now') }
+          rescue Timeout::Error
+            logger.info('shutdown -r now was called but timeout')
+          end
 
           sleep 5 until @machine.communicate.ready?
           @machine.ui.info(I18n.t("#{I18N_PREFIX}restarting_guest_done"))

--- a/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
@@ -7,6 +7,10 @@ module VagrantPlugins
     class Action
       # Action for configuring systemd on the guest
       class ConfigureSystemdProxy < Base
+        TMP_PATH = '/tmp/vagrant-proxyconf'
+        CONFIG_REGEXP = '^DefaultEnvironment.*#vagrant-proxyconf'
+        I18N_PREFIX = 'vagrant_proxyconf.systemd_proxy.'
+
         def config_name
           'systemd_proxy'
         end
@@ -21,38 +25,45 @@ module VagrantPlugins
         def configure_machine
           logger.info('Writing the proxy configuration to systemd config')
           write_systemd_config
+          reflect_config
         end
 
         def write_systemd_config
-          path = config_path
+          env_config =
+            "DefaultEnvironment=#{systemd_env_settings} #vagrant-proxyconf"
 
           @machine.communicate.tap do |comm|
-            if (comm.sudo(" systemctl show-environment | grep -c \"http_proxy=#{config.http || ''}\"").to_i rescue 0) == 0
-              comm.sudo("echo -e '#{systemd_env_settings}' >> #{path}")
-              comm.sudo(service_restart_command_low)
-              comm.sudo(service_restart_command_up)
-            end
+            comm.sudo("cp -p #{config_path} #{TMP_PATH}", error_check: false)
+            comm.sudo("grep -ve '#{CONFIG_REGEXP}' #{config_path} > #{TMP_PATH}")
+            comm.sudo("echo -e '#{env_config}' >> #{TMP_PATH}")
+            @restart_needed = !comm.test("diff -w #{TMP_PATH} #{config_path}")
+            comm.sudo("mv '#{TMP_PATH}' #{config_path}")
           end
         end
 
-        def service_restart_command_up
-          "systemctl set-environment \"HTTP_PROXY=#{config.http || ''}\" && " +
-            "systemctl set-environment \"HTTPS_PROXY=#{config.https || ''}\" && " +
-            "systemctl set-environment \"NO_PROXY=#{config.no_proxy || ''}\""
-        end
+        def reflect_config
+          return unless @restart_needed
+          @machine.ui.info(I18n.t("#{I18N_PREFIX}restarting_guest_start"))
+          @machine.communicate.sudo('shutdown -r now')
 
-        def service_restart_command_low
-          "systemctl set-environment \"http_proxy=#{config.http || ''}\" && " +
-            "systemctl set-environment \"https_proxy=#{config.https || ''}\" && " +
-            "systemctl set-environment \"no_proxy=#{config.no_proxy || ''}\" "
+          sleep 5 until @machine.communicate.ready?
+          @machine.ui.info(I18n.t("#{I18N_PREFIX}restarting_guest_done"))
         end
 
         def systemd_env_settings
-          "DefaultEnvironment=\"https_proxy=#{config.http || ''}\" "+
-            "\"http_proxy=#{config.http || ''}\" "+
-            "\"no_proxy=#{config.no_proxy || ''}\""
+          https_proxy = config.https    || ''
+          http_proxy  = config.http     || ''
+          ftp_proxy   = config.ftp      || ''
+          no_proxy    = config.no_proxy || ''
+          ["HTTPS_PROXY=#{https_proxy}",
+            "HTTP_PROXY=#{http_proxy}",
+            "FTP_PROXY=#{ftp_proxy}",
+            "NO_PROXY=#{no_proxy}",
+            "https_proxy=#{https_proxy}",
+            "http_proxy=#{http_proxy}",
+            "ftp_proxy=#{ftp_proxy}",
+            "no_proxy=#{no_proxy}"].join(' ')
         end
-
       end
     end
   end

--- a/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_systemd_proxy.rb
@@ -1,0 +1,66 @@
+require_relative 'base'
+require_relative '../resource'
+require_relative '../userinfo_uri'
+
+module VagrantPlugins
+  module ProxyConf
+    class Action
+      # Action for configuring systemd on the guest
+      class ConfigureSystemdProxy < Base
+        def config_name
+          'systemd_proxy'
+        end
+
+        private
+
+        def config
+          # Use global proxy config
+          @config ||= finalize_config(@machine.config.proxy)
+        end
+
+        def configure_machine
+          logger.info('Writing the proxy configuration to systemd config')
+          detect_export
+          write_systemd_config
+        end
+
+        def write_systemd_config
+          path = config_path
+
+          @machine.communicate.tap do |comm|
+            if (comm.sudo(" systemctl show-environment | grep -c \"http_proxy=#{config.http || ''}\"").to_i rescue 0) == 0
+              comm.sudo("echo -e '#{systemd_env_settings}' >> #{path}")
+              comm.sudo(service_restart_command_low)
+              comm.sudo(service_restart_command_up)
+            end
+          end
+        end
+
+        def detect_export
+          @machine.communicate.tap do |comm|
+            comm.test('which systemctl') ? @export = '' : @export = 'export '
+          end
+        end
+
+        def service_restart_command_up
+          "systemctl set-environment \"HTTP_PROXY=#{config.http || ''}\" && " +
+            "systemctl set-environment \"HTTPS_PROXY=#{config.https || ''}\" && " +
+            "systemctl set-environment \"NO_PROXY=#{config.no_proxy || ''}\""
+        end
+
+        def service_restart_command_low
+          "systemctl set-environment \"http_proxy=#{config.http || ''}\" && " +
+            "systemctl set-environment \"https_proxy=#{config.https || ''}\" && " +
+            "systemctl set-environment \"no_proxy=#{config.no_proxy || ''}\" "
+        end
+
+        def systemd_env_settings
+          "DefaultEnvironment=\"https_proxy=#{config.http || ''}\" "+
+            "\"http_proxy=#{config.http || ''}\" "+
+            "\"no_proxy=#{config.no_proxy || ''}\""
+        end
+
+      end
+    end
+  end
+end

--- a/lib/vagrant-proxyconf/cap/linux/systemd_proxy_conf.rb
+++ b/lib/vagrant-proxyconf/cap/linux/systemd_proxy_conf.rb
@@ -8,15 +8,10 @@ module VagrantPlugins
         module SystemdProxyConf
           # @return [String, false] the path to systemd or `false` if not found
           def self.systemd_proxy_conf(machine)
-            systemd_command = 'systemctl'    if Util.which(machine, 'systemctl')
-
+            systemd_command = 'systemctl' if Util.which(machine, 'systemctl')
             return false if systemd_command.nil?
 
-            if machine.communicate.test('cat /etc/redhat-release')
-              "/etc/systemd/system.conf"
-            else
-              raise 'implement for your linux'
-            end
+            '/etc/systemd/system.conf'
           end
         end
       end

--- a/lib/vagrant-proxyconf/cap/linux/systemd_proxy_conf.rb
+++ b/lib/vagrant-proxyconf/cap/linux/systemd_proxy_conf.rb
@@ -1,0 +1,25 @@
+require_relative '../util'
+
+module VagrantPlugins
+  module ProxyConf
+    module Cap
+      module Linux
+        # Capability for systemd proxy configuration
+        module SystemdProxyConf
+          # @return [String, false] the path to systemd or `false` if not found
+          def self.systemd_proxy_conf(machine)
+            systemd_command = 'systemctl'    if Util.which(machine, 'systemctl')
+
+            return false if systemd_command.nil?
+
+            if machine.communicate.test('cat /etc/redhat-release')
+              "/etc/systemd/system.conf"
+            else
+              raise 'implement for your linux'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-proxyconf/capability.rb
+++ b/lib/vagrant-proxyconf/capability.rb
@@ -8,6 +8,11 @@ module VagrantPlugins
         Cap::Debian::AptProxyConf
       end
 
+      guest_capability 'linux', 'systemd_proxy_conf' do
+        require_relative 'cap/linux/systemd_proxy_conf'
+        Cap::Linux::SystemdProxyConf
+      end
+
       guest_capability 'linux', 'docker_proxy_conf' do
         require_relative 'cap/linux/docker_proxy_conf'
         Cap::Linux::DockerProxyConf

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,6 +8,14 @@ en:
       configuring: |-
         Configuring proxy for Apt...
 
+    systemd_proxy:
+      not_enabled: |-
+        systemd_proxy not enabled or configured
+      not_supported: |-
+        Skipping Systemd proxy config as the machine does not support it
+      configuring: |-
+        Configuring proxy for Systemd...
+
     docker_proxy:
       not_enabled: |-
         docker_proxy not enabled or configured

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -15,6 +15,10 @@ en:
         Skipping Systemd proxy config as the machine does not support it
       configuring: |-
         Configuring proxy for Systemd...
+      restarting_guest_start: |-
+        Restarting Guest VM to reflect Systemd proxy settings...
+      restarting_guest_done: |-
+        DONE: Restarting Guest VM
 
     docker_proxy:
       not_enabled: |-

--- a/spec/unit/vagrant-proxyconf/cap/linux/systemd_proxy_conf_spec.rb
+++ b/spec/unit/vagrant-proxyconf/cap/linux/systemd_proxy_conf_spec.rb
@@ -12,24 +12,12 @@ describe VagrantPlugins::ProxyConf::Cap::Linux::SystemdProxyConf do
       allow(machine).to receive(:communicate) { communicator }
     end
 
-    it "returns the path when systemd is installed on Redhat" do
+    it "returns the path when systemd is installed on Redhat/Ubuntu/Debian" do
       allow(VagrantPlugins::ProxyConf::Cap::Util).to receive(:which) do |_m, c|
         (c == 'systemctl') ? '/path/to/systemctl' : false
-      end
-      allow(communicator).to receive(:test) do |c|
-        c == 'cat /etc/redhat-release'
       end
 
       expect(described_class.systemd_proxy_conf(machine)).to eq '/etc/systemd/system.conf'
-    end
-
-    it "returns raise when systemd looking for on Debian or Ubuntu" do
-      allow(VagrantPlugins::ProxyConf::Cap::Util).to receive(:which) do |_m, c|
-        (c == 'systemctl') ? '/path/to/systemctl' : false
-      end
-      allow(communicator).to receive(:test) { false }
-
-      expect { described_class.systemd_proxy_conf(machine) }.to raise_error
     end
 
     it "returns false when systemd is not installed" do

--- a/spec/unit/vagrant-proxyconf/cap/linux/systemd_proxy_conf_spec.rb
+++ b/spec/unit/vagrant-proxyconf/cap/linux/systemd_proxy_conf_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'vagrant-proxyconf/cap/linux/systemd_proxy_conf'
+require 'vagrant-proxyconf/cap/util'
+
+describe VagrantPlugins::ProxyConf::Cap::Linux::SystemdProxyConf do
+
+  describe '.systemd_proxy_conf' do
+    let(:machine) { double }
+    let(:communicator) { double }
+
+    before do
+      allow(machine).to receive(:communicate) { communicator }
+    end
+
+    it "returns the path when systemd is installed on Redhat" do
+      allow(VagrantPlugins::ProxyConf::Cap::Util).to receive(:which) do |_m, c|
+        (c == 'systemctl') ? '/path/to/systemctl' : false
+      end
+      allow(communicator).to receive(:test) do |c|
+        c == 'cat /etc/redhat-release'
+      end
+
+      expect(described_class.systemd_proxy_conf(machine)).to eq '/etc/systemd/system.conf'
+    end
+
+    it "returns raise when systemd looking for on Debian or Ubuntu" do
+      allow(VagrantPlugins::ProxyConf::Cap::Util).to receive(:which) do |_m, c|
+        (c == 'systemctl') ? '/path/to/systemctl' : false
+      end
+      allow(communicator).to receive(:test) { false }
+
+      expect { described_class.systemd_proxy_conf(machine) }.to raise_error
+    end
+
+    it "returns false when systemd is not installed" do
+      allow(VagrantPlugins::ProxyConf::Cap::Util).to receive(:which) { false }
+      expect(described_class.systemd_proxy_conf(machine)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Because #114 is stopped, I have duplicate the pull request and add modifications.

~~I will add more description for this pull request, soon.~~(Added by @otahi at 2015-10-15 06:35:17 +0900)

Some Linux distributions use systemd as alternative a system management daemon.
Systemd can pass environment variables services which launched by systemd.
If proxy configuration changes, target guests to be restarted.

Systemd is major in these days. We need to test following distributions at least.
- Systemd
  - Ubuntu 15.04
  - RHEL 7.0
  - CoreOS
  - ArchLinux
-  Non-Systemd
  - Ubuntu 14.04
  - RHEL 6.0

CC/@flaccid, @dimafujitsu
