### PR TITLE
Docker config is invalid

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_docker_proxy.rb
@@ -83,10 +83,10 @@ module VagrantPlugins
 
         def docker_config
           <<-CONFIG.gsub(/^\s+/, '')
-            #{@export}HTTP_PROXY=#{config.http || ''}
-            #{@export}NO_PROXY=#{config.no_proxy || ''}
-            #{@export}http_proxy=#{config.http || ''}
-            #{@export}no_proxy=#{config.no_proxy || ''}
+            #{@export}HTTP_PROXY=\"#{config.http || ''}\"
+            #{@export}NO_PROXY=\"#{config.no_proxy || ''}\"
+            #{@export}http_proxy=\"#{config.http || ''}\"
+            #{@export}no_proxy=\"#{config.no_proxy || ''}\"
           CONFIG
         end
       end


### PR DESCRIPTION
Docker (at least, v1.9.1) requires that values in the config file are enclosed in quotes. The current code doesn't do this, resulting in a corrupt file that prevents docker from starting.
