### PR TITLE
Fix CI errors on Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /doc
 /tmp
 vagrant-proxyconf-*.gem
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,13 @@ before_install:
 bundler_args: --without=development
 
 rvm: 2.0.0
-env: VAGRANT_VERSION=v1.7.2
+env: VAGRANT_VERSION=v1.8.1
 matrix:
   include:
+    - env: VAGRANT_VERSION=v1.7.2
     - env: VAGRANT_VERSION=v1.6.5
     - env: VAGRANT_VERSION=v1.5.4
     - env: VAGRANT_VERSION=v1.4.3
-    - env: VAGRANT_VERSION=v1.3.5
-      rvm: 1.9.3
-    - env: VAGRANT_VERSION=v1.2.7
-      rvm: 1.9.3
     - env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master


### PR DESCRIPTION
I have arrange the CI matrix. I have removed old vagrant versions with ruby 1.9.3.
[Broken CI](https://travis-ci.org/tmatilai/vagrant-proxyconf/builds/110492497) should be repaired.
