### PR TITLE
yum disable fastestmirror

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_yum_proxy.rb
@@ -26,6 +26,7 @@ module VagrantPlugins
             comm.sudo("chown root:root #{path}.new")
             comm.sudo("mv -f #{path}.new #{path}")
             comm.sudo("rm -f #{tmp}")
+            comm.sudo("sed -i 's/.*enabled=.*/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf", error_check: false)
           end
         end
 


### PR DESCRIPTION
#54, https://wiki.centos.org/PackageManagement/Yum/FastestMirror say that fastestmirror should not be used behind a proxy
