### PR TITLE
fix password update errors occurring if the old password contains an equal sign

### DIFF
--- a/resources/yum_config.awk
+++ b/resources/yum_config.awk
@@ -39,6 +39,7 @@ BEGIN {
 $1 ~ /^proxy(_username|_password)?$/ {
   if (main == 1) {
     $2 = conf[$1]
+    NF = 2
     seen[$1] = 1
   }
 }

--- a/spec/unit/fixtures/yum_with_repository_and_proxy_containing_special_chars.conf
+++ b/spec/unit/fixtures/yum_with_repository_and_proxy_containing_special_chars.conf
@@ -1,0 +1,10 @@
+[main]
+debuglevel=2
+plugins=1
+proxy=http://proxy.example.com:3128/
+proxy_username=foo
+proxy_password=bar=baz
+[myrepo]
+name=My Repository
+baseurl=http://myrepo/somewhere
+proxy=http://repoproxy:8080

--- a/spec/unit/vagrant-proxyconf/resources/yum_config_spec.rb
+++ b/spec/unit/vagrant-proxyconf/resources/yum_config_spec.rb
@@ -69,6 +69,20 @@ describe 'resources/yum_config.awk' do
       end
     end
 
+    context "with old proxy conf containing special characters" do
+      let(:old_conf) { 'yum_with_repository_and_proxy_containing_special_chars.conf' }
+
+      it "replaces existing proxy and userinfo" do
+        conf = { proxy: 'http://proxy.example.com:3128/', user: 'foo', pass: 'bar' }
+        expect(configure(conf)).to eq fixture('yum_with_repository_and_proxy.conf')
+      end
+
+      it "disables existing proxy" do
+        conf = { proxy: '', user: 'baz', pass: 'bar' }
+        expect(configure(conf)).to eq fixture('yum_with_repository_and_disabled_proxy.conf')
+      end
+    end
+
     context "without userinfo" do
       let(:old_conf) { 'yum_with_repository_and_proxy_without_userinfo.conf' }
 


### PR DESCRIPTION
Hi Teemu,

I encountered a bug with passwords containing an equal sign that this pull request fixes. It contains of a test case and a (tiny) fix.

See a travis build after adding the test case: https://travis-ci.org/vboerchers/vagrant-proxyconf/jobs/146726635

Then the build after the fix: https://travis-ci.org/vboerchers/vagrant-proxyconf/builds/146728113 (remaining errors are due to ruby/rake incompatibilties).

BTW this fixes part of #140 although this has nothing to do with escaping special characters.

Regards
Volker
