### PR TITLE
Fix special chars in proxy password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,11 @@ source 'https://rubygems.org'
 
 gem 'vagrant',
   git: 'https://github.com/mitchellh/vagrant.git',
-  ref: ENV.fetch('VAGRANT_VERSION', 'v1.7.2')
+  ref: ENV.fetch('VAGRANT_VERSION', 'v1.9.4')
 
 gem 'cane', '~> 2.6'
 gem 'coveralls', require: false
-gem 'rake'
+gem 'rake', '< 11.0'
 gem 'rspec', '~> 3.1'
 gem 'rspec-its', '~> 1.0'
 gem 'tailor', '~> 1.4'

--- a/lib/vagrant-proxyconf/action/configure_env_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_env_proxy.rb
@@ -107,14 +107,14 @@ module VagrantPlugins
 
         def environment_config
           <<-CONFIG.gsub(/^\s+/, '')
-            HTTP_PROXY=#{config.http || ''}
-            HTTPS_PROXY=#{config.https || ''}
-            FTP_PROXY=#{config.ftp || ''}
-            NO_PROXY=#{config.no_proxy || ''}
-            http_proxy=#{config.http || ''}
-            https_proxy=#{config.https || ''}
-            ftp_proxy=#{config.ftp || ''}
-            no_proxy=#{config.no_proxy || ''}
+            HTTP_PROXY='#{config.http}'
+            HTTPS_PROXY='#{config.https}'
+            FTP_PROXY='#{config.ftp}'
+            NO_PROXY='#{config.no_proxy}'
+            http_proxy='#{config.http}'
+            https_proxy='#{config.https}'
+            ftp_proxy='#{config.ftp}'
+            no_proxy='#{config.no_proxy}'
           CONFIG
         end
       end

--- a/lib/vagrant-proxyconf/config/env_proxy.rb
+++ b/lib/vagrant-proxyconf/config/env_proxy.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
             # still in v1.0.x.
             value = value.inspect if key.name == :no_proxy
 
-            [var.upcase, var.downcase].map { |v| "export #{v}=#{value}\n" }.join
+            [var.upcase, var.downcase].map { |v| "export #{v}='#{value}'\n" }.join
           end
         end
 


### PR DESCRIPTION
Using passwords with special chars can be problematic, since they can be 

```
export HTTP_PROXY=http://user:pa$wd@proxy:80
env | grep HTTP_PROXY
=> HTTP_PROXY=http://user:pa@proxy:80
```

* needed to update vagrant version to 1.9.4, since it would not build gem otherwise.
* pinned rake version to 11.0, otherwise build gem will fail.
* used single quotes for env proxy and proxy.sh

