### PR TITLE
Update default Vagrant version and build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,22 @@ sudo: false
 before_install: ./travis/before_install
 bundler_args: --without=development
 
-rvm: 2.3.4
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+rvm: 2.4.4
 matrix:
   include:
-    - env: VAGRANT_VERSION=v1.9.7
+    - env: VAGRANT_VERSION=v2.2.2
+    - env: VAGRANT_VERSION=v2.1.5
+    - env: VAGRANT_VERSION=v2.0.4
+    - env: VAGRANT_VERSION=v1.9.8
+      rvm: 2.3.4
     - env:
         - VAGRANT_VERSION=v1.8.7
         - BUNDLER_VERSION=1.12.5
       rvm: 2.2.5
-    - env: VAGRANT_VERSION=v1.7.4
-      rvm: 2.0.0
-    - env:
-        - VAGRANT_VERSION=v1.6.5
-        - BUNDLER_VERSION="< 1.7.0, >= 1.5.2"
-      rvm: 2.0.0
-      gemfile: travis/Gemfile_1.6.5
-    - env:
-        - VAGRANT_VERSION=v1.5.4
-        - BUNDLER_VERSION="~> 1.5.2"
-      rvm: 2.0.0
-    - env: VAGRANT_VERSION=v1.4.3
-      rvm: 2.0.0
     - env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'vagrant',
-  git: 'https://github.com/mitchellh/vagrant.git',
-  ref: ENV.fetch('VAGRANT_VERSION', 'v1.9.7')
+    git: 'https://github.com/mitchellh/vagrant.git',
+    ref: ENV.fetch('VAGRANT_VERSION', 'v2.2.2')
 
 gem 'rake'
 gem 'rspec', '~> 3.1'
@@ -15,5 +15,5 @@ group :development do
 end
 
 group :plugins do
-  gem 'vagrant-proxyconf', path: File.dirname(__FILE__)
+  gem 'vagrant-proxyconf', path: __dir__
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rspec-its', '~> 1.0'
 group :development do
   gem 'guard-rspec'
   gem 'redcarpet'
-  gem 'yard', '~> 0.8'
+  gem 'yard', '~> 0.9.11'
 end
 
 group :plugins do

--- a/travis/Gemfile_1.6.5
+++ b/travis/Gemfile_1.6.5
@@ -1,4 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-
-# Lock down rack version for Ruby 2.0
-gem 'rack', '< 2.0'

--- a/travis/before_install
+++ b/travis/before_install
@@ -2,6 +2,11 @@
 
 set -eu -o pipefail
 
+remove_default_specs() {
+    echo "Removing default gemspec"
+    find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete
+}
+
 install_bundler() {
     echo "Uninstalling current Bundler versions"
     rvm @global do gem uninstall bundler --all --executables
@@ -10,6 +15,12 @@ install_bundler() {
     gem install bundler --version "$BUNDLER_VERSION"
 }
 
+print_bundler_version() {
+    bundler --version
+}
+
 if [ -n "${BUNDLER_VERSION:-}" ]; then
+    remove_default_specs
     install_bundler
+    print_bundler_version
 fi


### PR DESCRIPTION
* Update yard dependency for security
* Update Vagrant versions in the Travis build matrix
  - Add builds for 1.9-2.2, default to 2.2.2
  - Drop test support for Vagrant versions before 1.8
* Also hack around yet another Travis issues with Bundler