### PR TITLE
Provisioning of docker fails issue 180

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
     - env: VAGRANT_VERSION=v2.0.4
     - env: VAGRANT_VERSION=v1.9.8
       rvm: 2.3.4
-    - env:
-        - VAGRANT_VERSION=v1.8.7
-        - BUNDLER_VERSION=1.12.5
-      rvm: 2.2.5
     - env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1 / _Not released yet_
+
+
 # 2.0.0 / 2019-01-03
 
 Improvements:

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -9,13 +9,15 @@ RUN yum clean all && \
       curl \
       device-mapper-persistent-data \
       git \
+      initscripts \
       lvm2 \
       openssh-clients \ 
       openssh-server \ 
       rsync \ 
       sudo \
       wget \
-      yum-utils && \ 
+      yum-utils \ 
+      xfsprogs && \
     yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     yum clean expire-cache && \
     yum install -y docker-ce && \
@@ -31,10 +33,13 @@ RUN yum clean all && \
     mkdir -p /home/vagrant/.ssh && \
     touch /home/vagrant/.ssh/authorized_keys
 
+VOLUME [ "/sys/fs/cgroup" ]
+
 RUN grep -q 'OHlnVYCzRdK8jlqm8tehUc9c9WhQ==' /home/vagrant/.ssh/authorized_keys || echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==" >> /home/vagrant/.ssh/authorized_keys && \
     chmod 0600 /home/vagrant/.ssh/authorized_keys && \
     chown vagrant:vagrant /home/vagrant/.ssh/authorized_keys
 
 # -e write logs to stderr
 # -D run in foreground
-CMD ["/usr/sbin/sshd", "-e", "-D"]
+# CMD ["/usr/sbin/sshd", "-e", "-D"]
+CMD ["/usr/sbin/init"]

--- a/development/Vagrantfile.example
+++ b/development/Vagrantfile.example
@@ -133,9 +133,6 @@ Vagrant.configure('2') do |config|
   config.vm.define "default" do |default|
     # set this to true, if you want to use a global proxy
     default.proxy.enabled = false if !GLOBAL_PROXY_HOST
-    default.proxy.enabled = {
-      :apt => false
-    }
 
     default.vm.box = BOX
 
@@ -143,6 +140,17 @@ Vagrant.configure('2') do |config|
     default.vm.provision :shell, path: 'install-debian.sh'
 
     default.vm.network "private_network", ip: "70.70.70.10"
+
+    default.vm.provider :virtualbox do |vb, override|
+      # override.proxy.enabled = ENABLE_PROXY
+      vb.cpus = 1
+      vb.memory = 1024
+
+      vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ] if config.vm.box =~ /xenial|bionic/
+
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    end
   end
 
   config.vm.define "centos7-client" do |centos7|
@@ -152,16 +160,37 @@ Vagrant.configure('2') do |config|
     centos7.vm.network "private_network", ip: "70.70.70.20"
 
     centos7.vm.provision :shell, path: 'install-c7.sh'
+
+    config.vm.provider :virtualbox do |vb, override|
+      # override.proxy.enabled = ENABLE_PROXY
+      vb.cpus = 1
+      vb.memory = 1024
+
+      vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ] if config.vm.box =~ /xenial|bionic/
+
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    end
   end
 
-  config.vm.provider :virtualbox do |vb, override|
-    # override.proxy.enabled = ENABLE_PROXY
-    vb.cpus = 1
-    vb.memory = 1024
+  # config.vm.define "centos7-client" do |centos7|
+  #   centos7.proxy.enabled = config.proxy.enabled
+  #
+  #   centos7.vm.provider :docker do |d|
+  #     d.build_dir = '.'
+  #     d.dockerfile = 'Dockerfile'
+  #     d.has_ssh = true
+  #     # d.pull = true
+  #
+  #     if SUPPORTS_DOCKER_IN_DOCKER
+  #       d.volumes = [
+  #         "#{DOCKER_SOCKET}:#{DOCKER_SOCKET}",
+  #       ]
+  #       d.create_args = [
+  #         '--privileged',
+  #       ]
+  #     end
+  #   end
+  # end
 
-    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ] if config.vm.box =~ /xenial|bionic/
-
-    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-  end
 end

--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -123,8 +123,12 @@ module VagrantPlugins
           app_name = config_name.gsub(/_proxy/, '').to_sym
 
           if enabled.respond_to?(:key)
+            return false if enabled.has_key?(app_name) == false
+
             # if boolean value, return original behavior as mentioned in Readme
             return enabled[app_name] == false if [true, false].include?(enabled[app_name])
+
+            return false if enabled[app_name].has_key?(:skip) == false
 
             # otherwise assume new behavior using :enabled as a new hash key
             return enabled[app_name][:enabled] == false

--- a/lib/vagrant-proxyconf/action/base.rb
+++ b/lib/vagrant-proxyconf/action/base.rb
@@ -141,8 +141,12 @@ module VagrantPlugins
           app_name = config_name.gsub(/_proxy/, '').to_sym
 
           if enabled.respond_to?(:key)
+            return false if enabled.has_key?(app_name) == false
+
             # if boolean value, return original behavior as mentioned in Readme
             return enabled[app_name] == false if [true, false].include?(enabled[app_name])
+
+            return false if enabled[app_name].has_key?(:skip) == false
 
             # otherwise assume new behavior using :enabled as a new hash key
             return enabled[app_name][:skip] == true

--- a/lib/vagrant-proxyconf/action/is_enabled.rb
+++ b/lib/vagrant-proxyconf/action/is_enabled.rb
@@ -15,8 +15,25 @@ module VagrantPlugins
 
         private
 
+        def has_proxy_env_var?(var='HTTP_PROXY')
+          var_not_in_env = ENV[var].nil? || ENV[var] == ''
+          return false if var_not_in_env
+
+          true
+        end
+
+        def plugin_disabled?(config)
+          config.enabled == false || config.enabled == '' || config.enabled.nil? || config.enabled == {}
+        end
+
         def plugin_enabled?(config)
-          config.enabled != false && config.enabled != ''
+          return false if plugin_disabled?(config)
+
+          # check for existence of HTTP_PROXY and HTTPS_PROXY environment variables
+          has_proxy_var = has_proxy_env_var?('HTTP_PROXY') || has_proxy_env_var?('HTTPS_PROXY')
+          return false if has_proxy_var == false
+
+          true
         end
       end
     end

--- a/lib/vagrant-proxyconf/version.rb
+++ b/lib/vagrant-proxyconf/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ProxyConf
-    VERSION = '2.0.0'
+    VERSION = '2.0.1.dev'
   end
 end

--- a/spec/unit/vagrant-proxyconf/action/base_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/base_spec.rb
@@ -1,0 +1,191 @@
+require 'spec_helper'
+require 'vagrant-proxyconf/action/base'
+require 'vagrant-proxyconf/action/configure_apt_proxy'
+
+class MyBase < VagrantPlugins::ProxyConf::Action::Base
+
+  def config_name
+    'my_base'
+  end
+
+  private
+
+  def configure_machine
+  end
+
+  def unconfigure_machine
+  end
+
+end
+
+def create_base(machine, env)
+  base = MyBase.new(nil, env)
+  base.instance_variable_set(:@machine, machine)
+
+  expect(base.config_name).to eq 'my_base'
+
+  base
+end
+
+describe MyBase do
+  let(:machine) { double('machine') }
+
+  describe "#skip?" do
+    let(:config) { OpenStruct.new }
+    let(:env) { OpenStruct.new }
+
+    subject do
+      base = create_base(machine, env)
+      allow(machine).to receive_message_chain(:config, :proxy) { config }
+
+      base.send(:skip?)
+    end
+
+    context "when attempting to configure a app proxy that is not defined" do
+      before(:each) do
+        config.enabled = {:foobar => false}
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when config.proxy.enabled[:my_base] = false" do
+      before(:each) do
+        config.enabled = {:my_base => false}
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "when config.proxy.enabled[:my_base] = true" do
+      before(:each) do
+        config.enabled = {:my_base => true}
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when config.proxy.enabled[:my_base] = {}" do
+      before(:each) do
+        config.enabled = {}
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+
+    context "when config.proxy.enabled[:my_base] = {:enabled => false, :skip => false}" do
+      before(:each) do
+        config.enabled = {
+          :my_base => {
+            :enabled => false,
+            :skip    => false,
+          }
+        }
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when config.proxy.enabled[:my_base] = {:enabled => true, :skip => false}" do
+      before(:each) do
+        config.enabled = {
+          :my_base => {
+            :enabled => true,
+            :skip    => false,
+          }
+        }
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when config.proxy.enabled[:my_base] = {:enabled => true, :skip => true}" do
+      before(:each) do
+        config.enabled = {
+          :my_base => {
+            :enabled => true,
+            :skip    => true,
+          }
+        }
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "when config.proxy.enabled[:my_base] = {:enabled => false, :skip => true}" do
+      before(:each) do
+        config.enabled = {
+          :my_base => {
+            :enabled => false,
+            :skip    => true,
+          }
+        }
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "when config.proxy.enabled = false" do
+      before(:each) do
+        config.enabled = false
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context "when config.proxy.enabled = true " do
+      before(:each) do
+        config.enabled = true
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "when config.proxy.enable[:my_base] = {:enabled => true} and :skip key is missing" do
+      before(:each) do
+        config.enabled = {
+          :my_base => {
+            :enabled => false,
+          },
+        }
+        config.http    = 'http://foo-proxy-server:8080'
+        config.https   = 'http://foo-prxoy-server:8080'
+        config.ftp     = 'ftp://foo-proxy-server:8080'
+      end
+
+      it { is_expected.to eq false }
+    end
+  end
+
+end

--- a/spec/unit/vagrant-proxyconf/action/is_enabled_spec.rb
+++ b/spec/unit/vagrant-proxyconf/action/is_enabled_spec.rb
@@ -20,26 +20,176 @@ describe VagrantPlugins::ProxyConf::Action::IsEnabled do
     end
   end
 
-  [false, ''].each do |value|
-    context "with `config.proxy.enabled=#{value.inspect}`" do
-      let(:enabled) { value }
+  describe "#has_proxy_env_var?" do
+    subject do
+      is_enabled = described_class.new(app, env)
 
-      it "results to falsy" do
-        described_class.new(app, {}).call(env)
-        expect(env[:result]).to be_falsey
-      end
+      is_enabled.send(:has_proxy_env_var?, var)
     end
+
+    context "when HTTP_PROXY is set in the environment and config.proxy.enabled=true" do
+      let(:enabled) { true }
+      let(:var) { 'HTTP_PROXY' }
+
+      before :each do
+        ENV[var] = 'http://localhost:8888'
+      end
+
+      after :each do
+        ENV[var] = nil
+      end
+
+      it { expect(ENV[var]).to eq 'http://localhost:8888' }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when HTTPS_PROXY="" is set in the environment and config.proxy.enabled=true" do
+      let(:enabled) { true }
+      let(:var) { 'HTTPS_PROXY' }
+
+      before :each do
+        ENV[var] = ''
+      end
+
+      after :each do
+        ENV[var] = nil
+      end
+
+      it { expect(ENV[var]).to eq '' }
+      it { is_expected.to eq false }
+    end
+
   end
 
-  [nil, true, :auto, 'yes please'].each do |value|
-    context "with `config.proxy.enabled=#{value.inspect}`" do
-      let(:enabled) { value }
+  describe "#plugin_disabled?" do
 
-      it "results to truthy" do
-        described_class.new(app, {}).call(env)
-        expect(env[:result]).to be_truthy
+    subject do
+      is_enabled = described_class.new(app, env)
+      is_enabled.send(:plugin_disabled?, env[:machine].config.proxy)
+    end
+
+    context "given config.proxy.enabled=false" do
+      let(:enabled) { false }
+
+      it { is_expected.to eq true }
+    end
+
+    context "given config.proxy.enabled=''" do
+      let(:enabled) { "" }
+
+      it { is_expected.to eq true }
+    end
+
+    context "given config.proxy.enabled=nil" do
+      let(:enabled) { false }
+
+      it { is_expected.to eq true }
+    end
+
+    context "given config.proxy.enabled={}" do
+      let(:enabled) { false }
+
+      it { is_expected.to eq true }
+    end
+
+    context "given config.proxy.enabled={:foo => 'bar'}" do
+      let(:enabled) do
+        {:foo => 'bar'}
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "given config.proxy.enabled=true" do
+      let(:enabled) { true }
+
+      it { is_expected.to eq false }
+    end
+
+    context "given config.proxy.enabled='http://localhost:8080'" do
+      let(:enabled) { 'http://localhost:8080' }
+
+      it { is_expected.to eq false }
+    end
+
+  end
+
+  describe "#plugin_enabled?" do
+    subject do
+      is_enabled = described_class.new(app, env)
+      is_enabled.send(:plugin_enabled?, env[:machine].config.proxy)
+    end
+
+    context "when config.proxy.enabled=false and ENV['HTTP_PROXY']='http://localhost:8888'" do
+      let(:enabled) { false }
+      let(:var) { 'HTTP_PROXY' }
+
+      before :each do
+        ENV[var] = 'http://localhost:8888'
+      end
+
+      after :each do
+        ENV[var] = nil
+      end
+
+      it { is_expected.to eq false }
+    end
+
+  end
+
+  describe "#call" do
+    [false, '', {}, nil].each do |value|
+      context "with `config.proxy.enabled=#{value.inspect}`" do
+        let(:enabled) { value }
+
+        it "results to falsy" do
+          described_class.new(app, {}).call(env)
+          expect(env[:result]).to be_falsey
+        end
       end
     end
+
+    [true, :auto, 'yes please', {:foo => 'yes'}].each do |value|
+      context "with `config.proxy.enabled=#{value.inspect}` and HTTP_PROXY=http://localhost:8888" do
+        let(:enabled) { value }
+        let(:var) { 'HTTP_PROXY' }
+
+        before :each do
+          ENV[var] = 'http://localhost:8888'
+        end
+
+        after :each do
+          ENV[var] = nil
+        end
+
+        it "results to truthy" do
+          described_class.new(app, {}).call(env)
+          expect(env[:result]).to be_truthy
+        end
+      end
+    end
+
+    [true, :auto, 'yes please', {:foo => 'yes'}].each do |value|
+      context "with `config.proxy.enabled=#{value.inspect}` and HTTP_PROXY=''" do
+        let(:enabled) { value }
+        let(:var) { 'HTTP_PROXY' }
+
+        before :each do
+          ENV[var] = ''
+        end
+
+        after :each do
+          ENV[var] = nil
+        end
+
+        it "results to truthy" do
+          described_class.new(app, {}).call(env)
+          expect(env[:result]).to be_falsey
+        end
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Attempt to address #180, #181 

Overview of Bugfix/Features
-----------------------------

The vagrant-proxyconf plugin is installed
AND
no config.proxy.* are set in a Vagrantfile

```
Vagrant.configure("2") do |config|
    config.vm.provider "docker" do |d|
      d.image = "hello-world"
    end
end
```

The pull request addresses this problem by disabling the vagrant-proxyconf plugin.

## The second feature of this pull request 

Adds additional logic to check if a proxy should be configured
Given either of the following environment variables being set
`export HTTP_PROXY=http://$my_proxy_host:$my_proxy_port`
*OR*
`export HTTPS_PROXY=https://$my_proxy_host:$my_proxy_port`
*AND*
Given this `Vagrantfile`

```
Vagrant.configure("2") do |config|

    if Vagrant.has_plugin?("vagrant-proxyconf")
      config.proxy.http      = "#{ENV['HTTP_PROXY']}"
      config.proxy.https     = "#{ENV['HTTPS_PROXY']}"
      config.proxy.no_proxy  = "#{ENV['NO_PROXY']}"
    end

    config.vm.provider "docker" do |d|
      d.image = "hello-world"
    end
end
```

The `vagrant-proxyconf` plugin would be enabled for all capable providers on the guest. However, if you didn't set `HTTP_PROXY` or `HTTPS_PROXY` in your environment before running vagrant up or vagrant provision then there is new logic to disable `vagrant-proxyconf` from attempting to configure your guest.

The new logic is an attempt to _auto-configure_ the `vagrant-proxyconf` providers based off your current environment proxy variables.