### PR TITLE
Apt proxy verify host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 
-rvm: 2.4.4
+rvm: 2.6.3
 matrix:
   include:
+    - env: VAGRANT_VERSION=v2.2.4
     - env: VAGRANT_VERSION=v2.2.2
     - env: VAGRANT_VERSION=v2.1.5
     - env: VAGRANT_VERSION=v2.0.4
+      rvm: 2.4.6
     - env: VAGRANT_VERSION=v1.9.8
-      rvm: 2.3.4
+      rvm: 2.3.7
     - env: VAGRANT_VERSION=master
   allow_failures:
     - env: VAGRANT_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
   include:
     - env: VAGRANT_VERSION=v2.2.4
     - env: VAGRANT_VERSION=v2.2.2
+      rvm: 2.4.6
     - env: VAGRANT_VERSION=v2.1.5
+      rvm: 2.4.6
     - env: VAGRANT_VERSION=v2.0.4
       rvm: 2.4.6
     - env: VAGRANT_VERSION=v1.9.8

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 #### End Added due to https://groups.google.com/forum/#!topic/vagrant-up/J8J6LmhzBqM/discussion
 
 gem 'vagrant',
-    git: 'https://github.com/mitchellh/vagrant.git',
+    git: 'https://github.com/hashicorp/vagrant.git',
     ref: ENV.fetch('VAGRANT_VERSION', 'v2.2.4')
 
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 
 gem 'vagrant',
     git: 'https://github.com/mitchellh/vagrant.git',
-    ref: ENV.fetch('VAGRANT_VERSION', 'v2.2.2')
+    ref: ENV.fetch('VAGRANT_VERSION', 'v2.2.4')
 
 gem 'rake'
 gem 'rspec', '~> 3.1'

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -20,6 +20,12 @@ module VagrantPlugins
         # @return [String] the FTP proxy
         key :ftp, env_var: 'VAGRANT_APT_FTP_PROXY'
 
+        # @return [String] whether APT should verify peer certificate
+        key :verify_peer, env_var: 'VAGRANT_APT_VERIFY_PEER'
+
+        # @return [String] whether APT should verify that certificate name matches server name
+        key :verify_host, env_var: 'VAGRANT_APT_VERIFY_HOST'
+
         def finalize!
           super
 
@@ -55,13 +61,17 @@ module VagrantPlugins
           end
 
           def to_s
-            direct || "#{prefix}#{value}#{suffix}"
+            direct || verify || "#{prefix}#{value}#{suffix}"
           end
 
           private
 
           def direct
             'DIRECT' if value.upcase == 'DIRECT'
+          end
+
+          def verify
+            value if ["true", "false"].to_set.contains? value
           end
 
           # Hash of deprecation warning sentinels

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -39,7 +39,15 @@ module VagrantPlugins
 
         # (see KeyMixin#config_for)
         def config_for(key, value)
-          %Q{Acquire::#{key.name}::Proxy #{value.inspect};\n} if value
+          if value
+            if key.name == :verify_host
+              %Q{Acquire::https::Verify-Host #{value.inspect};\n}
+            elsif key.name == :verify_peer
+              %Q{Acquire::https::Verify-Peer #{value.inspect};\n}
+            else
+              %Q{Acquire::#{key.name}::Proxy #{value.inspect};\n}
+            end
+          end
         end
 
         def finalize_uri(key, value)
@@ -71,7 +79,7 @@ module VagrantPlugins
           end
 
           def verify
-            value if ["true", "false"].to_set.contains? value
+            value if ["true", "false"].to_set.include? value
           end
 
           # Hash of deprecation warning sentinels

--- a/spec/unit/support/shared/apt_proxy_config.rb
+++ b/spec/unit/support/shared/apt_proxy_config.rb
@@ -8,6 +8,10 @@ end
 def conf_line(proto, name, port = 3142)
   if name == :direct
     %Q{Acquire::#{proto}::Proxy "DIRECT";\n}
+  elsif proto == :verify_peer
+    %Q{Acquire::https::Verify-Peer "#{name}";\n}
+  elsif proto == :verify_host
+    %Q{Acquire::https::Verify-Host "#{name}";\n}
   else
     port = ":#{port}" if port
     %Q{Acquire::#{proto}::Proxy "#{proto}://#{name}#{port}";\n}
@@ -62,6 +66,14 @@ shared_examples "apt proxy config" do |proto|
         subject        { config_with(proto => direct) }
         its(:enabled?) { should be_truthy }
         its(:to_s)     { should eq conf_line(proto, :direct) }
+      end
+    end
+
+    [:verify_peer, :verify_host].each do |verify|
+      context "with #{verify.inspect}" do
+        subject        { config_with(verify => "false") }
+        its(:enabled?) { should be_truthy }
+        its(:to_s)     { should eq conf_line(verify, "false") }
       end
     end
 

--- a/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
@@ -19,8 +19,6 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
   include_examples "apt proxy config", "http"
   include_examples "apt proxy config", "https"
   include_examples "apt proxy config", "ftp"
-  include_examples "apt proxy config", "verify_host"
-  include_examples "apt proxy config", "verify_peer"
 
   context "with both http and https proxies" do
     subject        { config_with(http: "10.2.3.4", https: "ssl-proxy:8443") }
@@ -33,8 +31,6 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
     include_examples "apt proxy env var", "VAGRANT_APT_HTTP_PROXY", "http"
     include_examples "apt proxy env var", "VAGRANT_APT_HTTPS_PROXY", "https"
     include_examples "apt proxy env var", "VAGRANT_APT_FTP_PROXY", "ftp"
-    include_examples "apt proxy env var", "VAGRANT_APT_VERIFY_HOST", "verify_host"
-    include_examples "apt proxy env var", "VAGRANT_APT_VERIFY_PEER", "verify_peer"
   end
 
 end

--- a/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
+++ b/spec/unit/vagrant-proxyconf/config/apt_proxy_spec.rb
@@ -19,6 +19,8 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
   include_examples "apt proxy config", "http"
   include_examples "apt proxy config", "https"
   include_examples "apt proxy config", "ftp"
+  include_examples "apt proxy config", "verify_host"
+  include_examples "apt proxy config", "verify_peer"
 
   context "with both http and https proxies" do
     subject        { config_with(http: "10.2.3.4", https: "ssl-proxy:8443") }
@@ -31,6 +33,8 @@ describe VagrantPlugins::ProxyConf::Config::AptProxy do
     include_examples "apt proxy env var", "VAGRANT_APT_HTTP_PROXY", "http"
     include_examples "apt proxy env var", "VAGRANT_APT_HTTPS_PROXY", "https"
     include_examples "apt proxy env var", "VAGRANT_APT_FTP_PROXY", "ftp"
+    include_examples "apt proxy env var", "VAGRANT_APT_VERIFY_HOST", "verify_host"
+    include_examples "apt proxy env var", "VAGRANT_APT_VERIFY_PEER", "verify_peer"
   end
 
 end


### PR DESCRIPTION
An attempt to add the following proxy options to APT. Any helps would be much appreciated.

```perl
Acquire::https::Verify-Host "false";
Acquire::https::Verify-Peer "false";
```