### PR TITLE
feature: support apt proxy when behind a proxy that terminates SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,81 @@
+# 2.0.5 / NOT_RELEASED_YET
+
+Credit to this release @greut. Thank you for your detailed information and for reporting a solution.
+
+This is a feature enhancement for the APT proxy configuration when using
+a proxy that is terminating SSL.  By default, these settings are left
+as-is and only enabled when a user wants to configure these settings.
+This feature supports enabling/disabling the follwoing settings
+
+#### file `/etc/apt/apt.conf.d/01proxy`
+
+```
+Acquire::https::Verify-Host
+Acquire::https::Verify-Peer
+```
+
+#### Configuration settings for `Acquire::https::Verify-Host` and `Acquire::https::Verify-Peer`
+
+  * The value for these settings must be a string.
+  * When `"true"` enable the setting
+  * When `"false"` disable the setting
+  * When `""` this setting is removed.
+
+#### Example Inside the Vagrantfile
+
+```
+Vagrant.configure("2") do |config|
+
+  config.vm.define 'apt_host' do |c|
+    c.vm.box = "bento/ubuntu-18.04"
+
+    if Vagrant.has_plugin?('vagrant-proxyconf')
+      c.proxy.http     = ENV['HTTP_PROXY']
+      c.proxy.https    = ENV['HTTPS_PROXY']
+      c.proxy.no_proxy = ENV['NO_PROXY']
+      c.apt_proxy.verify_host = "false"
+      c.apt_proxy.verify_peer = "false"
+
+      c.proxy.enabled = {
+        :apt => {
+          :enabled => true,
+          :skip    => false,
+        },
+        :env => {
+          :enabled => true,
+          :skip    => false,
+        },
+        :git => {
+          :enabled => true,
+          :skip    => false,
+        }
+      }
+    end
+  end
+
+end
+```
+
+#### Example setting the environment variables
+
+```
+export VAGRANT_APT_VERIFY_HOST="false"
+export VAGRANT_APT_VERIFY_PEER="false"
+vagrant up
+vagrant provision
+```
+
+**NOTE** If you change a setting in your `Vagrantfile` and the box is
+running, you can run `vagrant provision` or `vagrant reload` to adjust
+the settings.
+
+Supporting Issues:
+  - https://github.com/tmatilai/vagrant-proxyconf/issues/199
+
+Supporting Integration Tests:
+  - Look at the examples in directory [199](test/issues/199/)
+
+
 # 2.0.4 / 2019-07-24
 
 This is a bug fix release to address a logic issue for supporting docker

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ VAGRANT_APT_HTTP_PROXY="http://proxy.example.com:8080" vagrant up
 | apt       | `VAGRANT_APT_HTTP_PROXY`     | Configures APT http proxy     | Highest     |
 |           | `VAGRANT_APT_HTTPS_PROXY`    | Configures APT https proxy    | Highest     |
 |           | `VAGRANT_APT_FTP_PROXY`      | Configures APT ftp proxy      | Highest     |
+|           | `VAGRANT_APT_VERIFY_PEER`    | Configures APT Verify-Peer    | Highest     |
+|           | `VAGRANT_APT_VERIFY_HOST`    | Configures APT Verify-Host    | Highest     |
 | chef      | `VAGRANT_CHEF_HTTP_PROXY`    | Configures CHEF http proxy    | Highest     |
 |           | `VAGRANT_CHEF_HTTPS_PROXY`   | Configures CHEF https proxy   | Highest     |
 |           | `VAGRANT_CHEF_NO_PROXY`      | Configures CHEF no proxy      | Highest     |

--- a/lib/vagrant-proxyconf/config/apt_proxy.rb
+++ b/lib/vagrant-proxyconf/config/apt_proxy.rb
@@ -20,6 +20,12 @@ module VagrantPlugins
         # @return [String] the FTP proxy
         key :ftp, env_var: 'VAGRANT_APT_FTP_PROXY'
 
+        # @return [String] whether APT should verify peer certificate
+        key :verify_peer, env_var: 'VAGRANT_APT_VERIFY_PEER'
+
+        # @return [String] whether APT should verify that certificate name matches server name
+        key :verify_host, env_var: 'VAGRANT_APT_VERIFY_HOST'
+
         def finalize!
           super
 
@@ -33,7 +39,15 @@ module VagrantPlugins
 
         # (see KeyMixin#config_for)
         def config_for(key, value)
-          %Q{Acquire::#{key.name}::Proxy #{value.inspect};\n} if value
+          if value
+            if key.name == :verify_host
+              %Q{Acquire::https::Verify-Host #{value.inspect};\n}
+            elsif key.name == :verify_peer
+              %Q{Acquire::https::Verify-Peer #{value.inspect};\n}
+            else
+              %Q{Acquire::#{key.name}::Proxy #{value.inspect};\n}
+            end
+          end
         end
 
         def finalize_uri(key, value)
@@ -55,13 +69,18 @@ module VagrantPlugins
           end
 
           def to_s
-            direct || "#{prefix}#{value}#{suffix}"
+            # direct || "#{prefix}#{value}#{suffix}"
+            direct || verify || "#{prefix}#{value}#{suffix}"
           end
 
           private
 
           def direct
             'DIRECT' if value.upcase == 'DIRECT'
+          end
+
+          def verify
+            value if ["true", "false"].to_set.include? value
           end
 
           # Hash of deprecation warning sentinels

--- a/lib/vagrant-proxyconf/version.rb
+++ b/lib/vagrant-proxyconf/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ProxyConf
-    VERSION = '2.0.4'
+    VERSION = '2.0.5'
   end
 end

--- a/spec/unit/support/shared/apt_proxy_config.rb
+++ b/spec/unit/support/shared/apt_proxy_config.rb
@@ -8,6 +8,10 @@ end
 def conf_line(proto, name, port = 3142)
   if name == :direct
     %Q{Acquire::#{proto}::Proxy "DIRECT";\n}
+  elsif proto == :verify_peer
+    %Q{Acquire::https::Verify-Peer "#{name}";\n}
+  elsif proto == :verify_host
+    %Q{Acquire::https::Verify-Host "#{name}";\n}
   else
     port = ":#{port}" if port
     %Q{Acquire::#{proto}::Proxy "#{proto}://#{name}#{port}";\n}
@@ -62,6 +66,14 @@ shared_examples "apt proxy config" do |proto|
         subject        { config_with(proto => direct) }
         its(:enabled?) { should be_truthy }
         its(:to_s)     { should eq conf_line(proto, :direct) }
+      end
+    end
+
+    [:verify_peer, :verify_host].each do |verify|
+      context "with #{verify.inspect}" do
+        subject        { config_with(verify => "false") }
+        its(:enabled?) { should be_truthy }
+        its(:to_s)     { should eq conf_line(verify, "false") }
       end
     end
 

--- a/test/issues/199/.rspec
+++ b/test/issues/199/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/test/issues/199/Dockerfile
+++ b/test/issues/199/Dockerfile
@@ -1,0 +1,47 @@
+FROM centos:7
+
+ENV CI_USERNAME vagrant
+ENV CI_PASSWORD vagrant
+ENV CI_HOMEDIR  /home/vagrant
+ENV CI_SHELL    /bin/bash
+
+EXPOSE 8888
+
+RUN yum clean all && \
+    yum makecache fast && \
+    yum -y install epel-release && \
+    yum clean expire-cache && \
+    yum -y install \
+      curl \
+      initscripts \
+      openssh-clients \
+      openssh-server \
+      sudo \
+      tinyproxy
+
+RUN /usr/sbin/sshd-keygen && \
+    mkdir -p /var/run/sshd && \
+    rm -f /usr/lib/tmpfiles.d/systemd-nologin.conf
+
+RUN if ! getent passwd $CI_USERNAME; then \
+      useradd -m -d ${CI_HOMEDIR} -s ${CI_SHELL} $CI_USERNAME; \
+    fi && \
+    echo "${CI_USERNAME}:${CI_PASSWORD}" | chpasswd && \
+    echo "${CI_USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    mkdir -p /etc/sudoers.d && \
+    echo "${CI_USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${CI_USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${CI_USERNAME} && \
+    mkdir -p ${CI_HOMEDIR}/.ssh && \
+    chown -R ${CI_USERNAME}:${CI_USERNAME} ${CI_HOMEDIR}/.ssh && \
+    chmod 0700 ${CI_HOMEDIR}/.ssh && \
+    curl -L https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub > ${CI_HOMEDIR}/.ssh/vagrant.pub && \
+    touch ${CI_HOMEDIR}/.ssh/authorized_keys && \
+    grep -q "$(cat ${CI_HOMEDIR}/.ssh/vagrant.pub | awk '{print $2}')" ${CI_HOMEDIR}/.ssh/authorized_keys || cat ${CI_HOMEDIR}/.ssh/vagrant.pub >> ${CI_HOMEDIR}/.ssh/authorized_keys && \
+    chown ${CI_USERNAME}:${CI_USERNAME} ${CI_HOMEDIR}/.ssh/authorized_keys && \
+    chmod 0600 ${CI_HOMEDIR}/.ssh/authorized_keys
+
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "start" ]

--- a/test/issues/199/README.md
+++ b/test/issues/199/README.md
@@ -21,7 +21,7 @@ bundle exec vagrant up default
   - **NOTE**: You'll need to use `docker exec <hash> -it bash` to get into the container
 
 
-### Box `docker_host`
+### Box `apt_host`
 
   - Vagrant should automatically instally docker-ce.
   - The box should come up and provision itself with the proxy settings

--- a/test/issues/199/Rakefile
+++ b/test/issues/199/Rakefile
@@ -1,0 +1,27 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+    end
+  end
+end

--- a/test/issues/199/Vagrantfile
+++ b/test/issues/199/Vagrantfile
@@ -1,0 +1,74 @@
+# this should be the IP address of the :default box
+$PROXY_HOST ="10.0.2.2"
+$PROXY_PORT="8888"
+$PROXY_NO_PROXY=[
+  'localhost',
+]
+
+ENV['HTTP_PROXY']  = ENV.fetch('HTTP_PROXY',  "http://#{$PROXY_HOST}:#{$PROXY_PORT}")
+ENV['HTTPS_PROXY'] = ENV.fetch('HTTPS_PROXY', "https://#{$PROXY_HOST}:#{$PROXY_PORT}")
+ENV['NO_PROXY']    = ENV.fetch('NO_PROXY',    $PROXY_NO_PROXY.join(","))
+
+puts "HTTP_PROXY  = '#{ENV["HTTP_PROXY"]}'"
+puts "HTTPS_PROXY = '#{ENV["HTTPS_PROXY"]}'"
+puts "NO_PROXY    = '#{ENV["NO_PROXY"]}'"
+
+puts "vagrant-proxyconf is installed? #{Vagrant.has_plugin?('vagrant-proxyconf')}"
+
+$APT_PROXY_ENABLED = ENV.fetch("VAGRANT_APT_PROXY_ENABLED", "true")
+
+if $APT_PROXY_ENABLED == "false"
+  $APT_PROXY_ENABLED = false
+else
+  $APT_PROXY_ENABLED = true
+end
+
+Vagrant.configure("2") do |config|
+
+  config.vm.define 'default' do |c|
+    c.vm.box = nil
+
+    if Vagrant.has_plugin?('vagrant-proxyconf')
+      c.proxy.enabled = false
+    end
+
+    c.vm.provider "docker" do |d|
+      d.build_dir = "."
+      d.has_ssh = true
+      d.ports = [
+        "#{$PROXY_PORT}:#{$PROXY_PORT}",
+      ]
+    end
+  end
+
+  config.vm.define 'apt_host' do |c|
+    c.vm.box = "bento/ubuntu-18.04"
+
+    # ENV['VAGRANT_APT_VERIFY_HOST'] = "true"
+    # ENV['VAGRANT_APT_VERIFY_PEER'] = "false"
+
+    if Vagrant.has_plugin?('vagrant-proxyconf')
+      c.proxy.http     = ENV['HTTP_PROXY']
+      c.proxy.https    = ENV['HTTPS_PROXY']
+      c.proxy.no_proxy = ENV['NO_PROXY']
+      # uncomment the following to test different behaviors
+      # c.apt_proxy.verify_host = "true"
+      # c.apt_proxy.verify_peer = "false"
+      c.proxy.enabled = {
+        :apt => {
+          :enabled => $APT_PROXY_ENABLED,
+          :skip    => false,
+        },
+        :env => {
+          :enabled => false,
+          :skip    => false,
+        },
+        :git => {
+          :enabled => false,
+          :skip    => false,
+        }
+      }
+    end
+  end
+
+end

--- a/test/issues/199/entrypoint.sh
+++ b/test/issues/199/entrypoint.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -ex
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+start() {
+  # start ssh if sshd is installed
+  if [ -f /usr/sbin/sshd ]; then
+
+    /usr/sbin/sshd-keygen
+    /usr/sbin/sshd -t
+    /usr/sbin/sshd
+
+  else
+
+    true
+
+  fi
+
+  # start tinyproxy
+  /usr/sbin/tinyproxy \
+    -d \
+    -c "/etc/tinyproxy/tinyproxy.conf"
+}
+
+stop() {
+
+  pgrep -f 'sshd' | while read _pid
+  do
+    kill -9 $_pid
+  done
+
+  pgrep -f 'tinyproxy' | while read _pid
+  do
+    kill -9 $_pid
+  done
+
+}
+
+case "${1}" in
+
+  start)
+    start
+    ;;
+
+  stop)
+    stop
+    ;;
+
+esac

--- a/test/issues/199/spec/apt_host/ubuntu_spec.rb
+++ b/test/issues/199/spec/apt_host/ubuntu_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+PROXY_HOST = "10.0.2.2"
+
+context 'when proxy is enabled' do
+
+  before(:context) do
+    ENV['HTTP_PROXY']  = "http://#{PROXY_HOST}:8888"
+    ENV['HTTPS_PROXY'] = "https://#{PROXY_HOST}:8888"
+    ENV['NO_PROXY']    = "*.example.com"
+
+    `vagrant provision #{ENV['TARGET_HOST']}`
+    `sleep 3`
+  end
+
+  describe file('/etc/apt/apt.conf.d/01proxy') do
+    let(:expected_content) do
+      <<-EOS.gsub(/^\s+/, '')
+        Acquire::http::Proxy "http://10.0.2.2:8888";
+        Acquire::https::Proxy "https://10.0.2.2:8888";
+      EOS
+    end
+
+    its(:content) do
+       should eq(expected_content)
+    end
+  end
+
+end
+
+context 'when VAGRANT_APT_VERIFY_PEER="false"' do
+
+  before(:context) do
+    ENV['HTTP_PROXY']  = "http://#{PROXY_HOST}:8888"
+    ENV['HTTPS_PROXY']             = "https://#{PROXY_HOST}:8888"
+    ENV['NO_PROXY']                = "*.example.com"
+    ENV['VAGRANT_APT_VERIFY_PEER'] = "false"
+
+    `vagrant provision #{ENV['TARGET_HOST']}`
+    `sleep 3`
+  end
+
+  describe file('/etc/apt/apt.conf.d/01proxy') do
+    let(:expected_content) do
+      <<-EOS.gsub(/^\s+/, '')
+        Acquire::http::Proxy "http://10.0.2.2:8888";
+        Acquire::https::Proxy "https://10.0.2.2:8888";
+        Acquire::https::Verify-Peer "false";
+      EOS
+    end
+
+    its(:content) do
+       should eq(expected_content)
+    end
+  end
+
+end
+
+context 'when VAGRANT_APT_VERIFY_PEER="true" and VAGRANT_APT_VERIFY_HOST="false"' do
+
+  before(:context) do
+    ENV['HTTP_PROXY']  = "http://#{PROXY_HOST}:8888"
+    ENV['HTTPS_PROXY']             = "https://#{PROXY_HOST}:8888"
+    ENV['NO_PROXY']                = "*.example.com"
+    ENV['VAGRANT_APT_VERIFY_PEER'] = "true"
+    ENV['VAGRANT_APT_VERIFY_HOST'] = "false"
+
+    `vagrant provision #{ENV['TARGET_HOST']}`
+    `sleep 3`
+  end
+
+  describe file('/etc/apt/apt.conf.d/01proxy') do
+    let(:expected_content) do
+      <<-EOS.gsub(/^\s+/, '')
+        Acquire::http::Proxy "http://10.0.2.2:8888";
+        Acquire::https::Proxy "https://10.0.2.2:8888";
+        Acquire::https::Verify-Peer "true";
+        Acquire::https::Verify-Host "false";
+      EOS
+    end
+
+    its(:content) do
+       should eq(expected_content)
+    end
+  end
+
+end
+
+context 'when VAGRANT_APT_VERIFY_PEER="" and VAGRANT_APT_VERIFY_HOST=""' do
+
+  before(:context) do
+    ENV['HTTP_PROXY']  = "http://#{PROXY_HOST}:8888"
+    ENV['HTTPS_PROXY']             = "https://#{PROXY_HOST}:8888"
+    ENV['NO_PROXY']                = "*.example.com"
+    ENV['VAGRANT_APT_VERIFY_PEER'] = ""
+    ENV['VAGRANT_APT_VERIFY_HOST'] = ""
+
+    `vagrant provision #{ENV['TARGET_HOST']}`
+    `sleep 3`
+  end
+
+  describe file('/etc/apt/apt.conf.d/01proxy') do
+    let(:expected_content) do
+      <<-EOS.gsub(/^\s+/, '')
+        Acquire::http::Proxy "http://10.0.2.2:8888";
+        Acquire::https::Proxy "https://10.0.2.2:8888";
+      EOS
+    end
+
+    its(:content) do
+       should eq(expected_content)
+    end
+  end
+
+end
+
+context 'when VAGRANT_APT_VERIFY_PEER="true" and VAGRANT_APT_VERIFY_HOST="true" but proxy is disabled' do
+
+  before(:context) do
+    ENV['HTTP_PROXY']  = "http://#{PROXY_HOST}:8888"
+    ENV['HTTPS_PROXY']             = "https://#{PROXY_HOST}:8888"
+    ENV['NO_PROXY']                = "*.example.com"
+    ENV['VAGRANT_APT_VERIFY_PEER'] = "true"
+    ENV['VAGRANT_APT_VERIFY_HOST'] = "true"
+    ENV['VAGRANT_APT_PROXY_ENABLED'] = "false"
+
+    `vagrant provision #{ENV['TARGET_HOST']}`
+    `sleep 3`
+  end
+
+  describe file('/etc/apt/apt.conf.d/01proxy') do
+    it { should_not exist }
+  end
+
+end

--- a/test/issues/199/spec/default/redhat_spec.rb
+++ b/test/issues/199/spec/default/redhat_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe package('tinyproxy') do
+  it { should be_installed }
+end
+
+describe service('tinyproxy') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+
+describe port(8888) do
+  it { should be_listening }
+end

--- a/test/issues/199/spec/spec_helper.rb
+++ b/test/issues/199/spec/spec_helper.rb
@@ -1,0 +1,52 @@
+require 'serverspec'
+require 'net/ssh'
+require 'tempfile'
+
+set :backend, :ssh
+
+if ENV['ASK_SUDO_PASSWORD']
+  begin
+    require 'highline/import'
+  rescue LoadError
+    fail "highline is not available. Try installing it."
+  end
+  set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+else
+  set :sudo_password, ENV['SUDO_PASSWORD'] || "vagrant"
+end
+
+host = ENV['TARGET_HOST']
+
+`vagrant up #{host}`
+
+config = Tempfile.new('', Dir.tmpdir)
+config.write(`vagrant ssh-config #{host}`)
+config.close
+
+options = Net::SSH::Config.for(host, [config.path])
+
+options[:user] ||= Etc.getlogin
+
+set :host,        options[:host_name] || host
+set :ssh_options, options
+
+# Disable sudo
+# set :disable_sudo, true
+
+
+# Set environment variables
+set :env,
+  :LANG => 'C',
+  :LC_MESSAGES => 'C'
+
+# Set PATH
+# set :path, '/sbin:/usr/local/sbin:$PATH'
+set :path, [
+  '/usr/local/bin',
+  '/usr/local/sbin',
+  '/usr/bin',
+  '/usr/sbin',
+  '/bin',
+  '/sbin',
+  '$PATH',
+].join(':')

--- a/test/issues/199/tinyproxy.conf
+++ b/test/issues/199/tinyproxy.conf
@@ -1,0 +1,333 @@
+##
+## tinyproxy.conf -- tinyproxy daemon configuration file
+##
+## This example tinyproxy.conf file contains example settings
+## with explanations in comments. For decriptions of all
+## parameters, see the tinproxy.conf(5) manual page.
+##
+
+#
+# User/Group: This allows you to set the user and group that will be
+# used for tinyproxy after the initial binding to the port has been done
+# as the root user. Either the user or group name or the UID or GID
+# number may be used.
+#
+User tinyproxy
+Group tinyproxy
+
+#
+# Port: Specify the port which tinyproxy will listen on.  Please note
+# that should you choose to run on a port lower than 1024 you will need
+# to start tinyproxy using root.
+#
+Port 8888
+
+#
+# Listen: If you have multiple interfaces this allows you to bind to
+# only one. If this is commented out, tinyproxy will bind to all
+# interfaces present.
+#
+#Listen 192.168.0.1
+
+#
+# Bind: This allows you to specify which interface will be used for
+# outgoing connections.  This is useful for multi-home'd machines where
+# you want all traffic to appear outgoing from one particular interface.
+#
+#Bind 192.168.0.1
+
+#
+# BindSame: If enabled, tinyproxy will bind the outgoing connection to the
+# ip address of the incoming connection.
+#
+#BindSame yes
+
+#
+# Timeout: The maximum number of seconds of inactivity a connection is
+# allowed to have before it is closed by tinyproxy.
+#
+Timeout 600
+
+#
+# ErrorFile: Defines the HTML file to send when a given HTTP error
+# occurs.  You will probably need to customize the location to your
+# particular install.  The usual locations to check are:
+#   /usr/local/share/tinyproxy
+#   /usr/share/tinyproxy
+#   /etc/tinyproxy
+#
+#ErrorFile 404 "/usr/share/tinyproxy/404.html"
+#ErrorFile 400 "/usr/share/tinyproxy/400.html"
+#ErrorFile 503 "/usr/share/tinyproxy/503.html"
+#ErrorFile 403 "/usr/share/tinyproxy/403.html"
+#ErrorFile 408 "/usr/share/tinyproxy/408.html"
+
+#
+# DefaultErrorFile: The HTML file that gets sent if there is no
+# HTML file defined with an ErrorFile keyword for the HTTP error
+# that has occured.
+#
+DefaultErrorFile "/usr/share/tinyproxy/default.html"
+
+#
+# StatHost: This configures the host name or IP address that is treated
+# as the stat host: Whenever a request for this host is received,
+# Tinyproxy will return an internal statistics page instead of
+# forwarding the request to that host.  The default value of StatHost is
+# tinyproxy.stats.
+#
+#StatHost "tinyproxy.stats"
+#
+
+#
+# StatFile: The HTML file that gets sent when a request is made
+# for the stathost.  If this file doesn't exist a basic page is
+# hardcoded in tinyproxy.
+#
+StatFile "/usr/share/tinyproxy/stats.html"
+
+#
+# LogFile: Allows you to specify the location where information should
+# be logged to.  If you would prefer to log to syslog, then disable this
+# and enable the Syslog directive.  These directives are mutually
+# exclusive.
+#
+LogFile "/var/log/tinyproxy/tinyproxy.log"
+
+#
+# Syslog: Tell tinyproxy to use syslog instead of a logfile.  This
+# option must not be enabled if the Logfile directive is being used.
+# These two directives are mutually exclusive.
+#
+#Syslog On
+
+#
+# LogLevel: 
+#
+# Set the logging level. Allowed settings are:
+#	Critical	(least verbose)
+#	Error
+#	Warning
+#	Notice
+#	Connect		(to log connections without Info's noise)
+#	Info		(most verbose)
+#
+# The LogLevel logs from the set level and above. For example, if the
+# LogLevel was set to Warning, then all log messages from Warning to
+# Critical would be output, but Notice and below would be suppressed.
+#
+LogLevel Info
+
+#
+# PidFile: Write the PID of the main tinyproxy thread to this file so it
+# can be used for signalling purposes.
+#
+PidFile "/var/run/tinyproxy/tinyproxy.pid"
+
+#
+# XTinyproxy: Tell Tinyproxy to include the X-Tinyproxy header, which
+# contains the client's IP address.
+#
+#XTinyproxy Yes
+
+#
+# Upstream:
+#
+# Turns on upstream proxy support.
+#
+# The upstream rules allow you to selectively route upstream connections
+# based on the host/domain of the site being accessed.
+#
+# For example:
+#  # connection to test domain goes through testproxy
+#  upstream testproxy:8008 ".test.domain.invalid"
+#  upstream testproxy:8008 ".our_testbed.example.com"
+#  upstream testproxy:8008 "192.168.128.0/255.255.254.0"
+#
+#  # no upstream proxy for internal websites and unqualified hosts
+#  no upstream ".internal.example.com"
+#  no upstream "www.example.com"
+#  no upstream "10.0.0.0/8"
+#  no upstream "192.168.0.0/255.255.254.0"
+#  no upstream "."
+#
+#  # connection to these boxes go through their DMZ firewalls
+#  upstream cust1_firewall:8008 "testbed_for_cust1"
+#  upstream cust2_firewall:8008 "testbed_for_cust2"
+#
+#  # default upstream is internet firewall
+#  upstream firewall.internal.example.com:80
+#
+# The LAST matching rule wins the route decision.  As you can see, you
+# can use a host, or a domain:
+#  name     matches host exactly
+#  .name    matches any host in domain "name"
+#  .        matches any host with no domain (in 'empty' domain)
+#  IP/bits  matches network/mask
+#  IP/mask  matches network/mask
+#
+#Upstream some.remote.proxy:port
+
+#
+# MaxClients: This is the absolute highest number of threads which will
+# be created. In other words, only MaxClients number of clients can be
+# connected at the same time.
+#
+MaxClients 100
+
+#
+# MinSpareServers/MaxSpareServers: These settings set the upper and
+# lower limit for the number of spare servers which should be available.
+#
+# If the number of spare servers falls below MinSpareServers then new
+# server processes will be spawned.  If the number of servers exceeds
+# MaxSpareServers then the extras will be killed off.
+#
+MinSpareServers 5
+MaxSpareServers 20
+
+#
+# StartServers: The number of servers to start initially.
+#
+StartServers 10
+
+#
+# MaxRequestsPerChild: The number of connections a thread will handle
+# before it is killed. In practise this should be set to 0, which
+# disables thread reaping. If you do notice problems with memory
+# leakage, then set this to something like 10000.
+#
+MaxRequestsPerChild 0
+
+#
+# Allow: Customization of authorization controls. If there are any
+# access control keywords then the default action is to DENY. Otherwise,
+# the default action is ALLOW.
+#
+# The order of the controls are important. All incoming connections are
+# tested against the controls based on order.
+#
+Allow 127.0.0.1
+Allow 0.0.0.0/0
+
+#
+# AddHeader: Adds the specified headers to outgoing HTTP requests that
+# Tinyproxy makes. Note that this option will not work for HTTPS
+# traffic, as Tinyproxy has no control over what headers are exchanged.
+#
+#AddHeader "X-My-Header" "Powered by Tinyproxy"
+
+#
+# ViaProxyName: The "Via" header is required by the HTTP RFC, but using
+# the real host name is a security concern.  If the following directive
+# is enabled, the string supplied will be used as the host name in the
+# Via header; otherwise, the server's host name will be used.
+#
+ViaProxyName "tinyproxy"
+
+#
+# DisableViaHeader: When this is set to yes, Tinyproxy does NOT add
+# the Via header to the requests. This virtually puts Tinyproxy into
+# stealth mode. Note that RFC 2616 requires proxies to set the Via
+# header, so by enabling this option, you break compliance.
+# Don't disable the Via header unless you know what you are doing...
+#
+#DisableViaHeader Yes
+
+#
+# Filter: This allows you to specify the location of the filter file.
+#
+#Filter "/etc/tinyproxy/filter"
+
+#
+# FilterURLs: Filter based on URLs rather than domains.
+#
+#FilterURLs On
+
+#
+# FilterExtended: Use POSIX Extended regular expressions rather than
+# basic.
+#
+#FilterExtended On
+
+#
+# FilterCaseSensitive: Use case sensitive regular expressions.
+#
+#FilterCaseSensitive On
+
+#
+# FilterDefaultDeny: Change the default policy of the filtering system.
+# If this directive is commented out, or is set to "No" then the default
+# policy is to allow everything which is not specifically denied by the
+# filter file.
+#
+# However, by setting this directive to "Yes" the default policy becomes
+# to deny everything which is _not_ specifically allowed by the filter
+# file.
+#
+#FilterDefaultDeny Yes
+
+#
+# Anonymous: If an Anonymous keyword is present, then anonymous proxying
+# is enabled.  The headers listed are allowed through, while all others
+# are denied. If no Anonymous keyword is present, then all headers are
+# allowed through.  You must include quotes around the headers.
+#
+# Most sites require cookies to be enabled for them to work correctly, so
+# you will need to allow Cookies through if you access those sites.
+#
+#Anonymous "Host"
+#Anonymous "Authorization"
+#Anonymous "Cookie"
+
+#
+# ConnectPort: This is a list of ports allowed by tinyproxy when the
+# CONNECT method is used.  To disable the CONNECT method altogether, set
+# the value to 0.  If no ConnectPort line is found, all ports are
+# allowed (which is not very secure.)
+#
+# The following two ports are used by SSL.
+#
+ConnectPort 443
+ConnectPort 563
+
+#
+# Configure one or more ReversePath directives to enable reverse proxy
+# support. With reverse proxying it's possible to make a number of
+# sites appear as if they were part of a single site.
+#
+# If you uncomment the following two directives and run tinyproxy
+# on your own computer at port 8888, you can access Google using
+# http://localhost:8888/google/ and Wired News using
+# http://localhost:8888/wired/news/. Neither will actually work
+# until you uncomment ReverseMagic as they use absolute linking.
+#
+#ReversePath "/google/"	"http://www.google.com/"
+#ReversePath "/wired/"	"http://www.wired.com/"
+
+#
+# When using tinyproxy as a reverse proxy, it is STRONGLY recommended
+# that the normal proxy is turned off by uncommenting the next directive.
+#
+#ReverseOnly Yes
+
+#
+# Use a cookie to track reverse proxy mappings. If you need to reverse
+# proxy sites which have absolute links you must uncomment this.
+#
+#ReverseMagic Yes
+
+#
+# The URL that's used to access this reverse proxy. The URL is used to
+# rewrite HTTP redirects so that they won't escape the proxy. If you
+# have a chain of reverse proxies, you'll need to put the outermost
+# URL here (the address which the end user types into his/her browser).
+#
+# If not set then no rewriting occurs.
+#
+#ReverseBaseURL "http://localhost:8888/"
+
+
+
+
+### foo


### PR DESCRIPTION
This addresses issue #199

Includes two new configuration variables which are off by default.
The this feature now supports `Acquire::https::Verify-Peer` and  `Acquire::https::Verify-Host`

Supporting integration tests can be found in directory: [199](../test/issues/199/)