### PR TITLE
Unconfigure env_proxy correctly on windows guests.

### DIFF
--- a/lib/vagrant-proxyconf/action/configure_env_proxy.rb
+++ b/lib/vagrant-proxyconf/action/configure_env_proxy.rb
@@ -55,7 +55,9 @@ module VagrantPlugins
             logger.info("Setting #{key} to #{value}")
             @machine.communicate.sudo(command)
           else
-            logger.info("Not setting #{key}")
+            command = "[Environment]::SetEnvironmentVariable(\"#{key}\",$null,\"Machine\")"
+            logger.info("Removing #{key} environment variable")
+            @machine.communicate.sudo(command)
           end
         end
 


### PR DESCRIPTION
The documentation states the following:

> Empty string ("") or false in any setting also force the configuration files to be written, but without configuration for that key. Can be used to clear the old configuration and/or override a global setting.

It works as stated for Linux guests, but not for Windows guests.
The attached patch tries to resolve that.